### PR TITLE
Fix: signOut call in AuthWrapper for dev testing purpose removed.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,6 @@ import 'package:eventura/providers.dart';
 import 'package:eventura/ui/static/about_us.dart';
 import 'package:eventura/ui/static/contact_us.dart';
 import 'package:eventura/ui/static/faq.dart';
-import 'package:eventura/ui/views/events_list_view.dart';
 import 'package:eventura/ui/views/welcome_view.dart';
 import 'package:eventura/ui/widgets/auth_wrapper.dart';
 import 'package:flutter/material.dart';

--- a/lib/ui/widgets/auth_wrapper.dart
+++ b/lib/ui/widgets/auth_wrapper.dart
@@ -8,7 +8,7 @@ class AuthWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Supabase.instance.client.auth.signOut();
+    //Supabase.instance.client.auth.signOut();
     final user = Supabase.instance.client.auth.currentUser;
 
     if (user != null) {


### PR DESCRIPTION

- Removed signOut call at the beginning, it was there for the purpose of testing the whole auth logic.

- Removed an unnecessary import of events list in `main.dart`