### PR TITLE
Error fix in Sign up view and service

### DIFF
--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -155,13 +155,15 @@ class AuthService {
                   .select('user_id')
                   .eq('email', email)
                   .maybeSingle();
-
-          if (existingUser != null ||
-              ((existingUser ?? []) as List).isNotEmpty) {
-            var e = Exception("Email already in use.");
-            logger.e("Error: email already in use", error: e);
-            throw e;
+                  
+          if (existingUser != null) {
+            if (existingUser.isEmpty) {
+              var e = Exception("Email already in use.");
+              logger.e("Error: email already in use", error: e);
+              throw e;
+            }
           }
+
           final user = await createUser(newUser);
           return user;
         } catch (error) {

--- a/lib/ui/views/auth/signup_view.dart
+++ b/lib/ui/views/auth/signup_view.dart
@@ -1,9 +1,9 @@
 import 'package:eventura/core/viewmodels/auth/signup_viewmodel.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
+//import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
-import 'dart:io';
+//import 'dart:io';
 
 class SignupView extends StatelessWidget {
   final _emailController = TextEditingController();

--- a/lib/ui/views/auth/signup_view.dart
+++ b/lib/ui/views/auth/signup_view.dart
@@ -148,7 +148,8 @@ class SignupView extends StatelessWidget {
 
   void _showConfirmationDialog(BuildContext context) {
     final dialog =
-        Platform.isIOS
+    // code à décommenter en cas d'exécution sur appareil mobile
+    /* Platform.isIOS
             ? CupertinoAlertDialog(
               title: const Text("Email confirmation"),
               content: const Text(
@@ -161,27 +162,27 @@ class SignupView extends StatelessWidget {
                       () => Navigator.pushReplacementNamed(context, "/login"),
                 ),
               ],
-            )
-            : AlertDialog(
-              title: const Text("Email confirmation"),
-              content: const Text(
-                "Please confirm your email using the link we've sent you. You're going to be redirected to the sign in page.",
-              ),
-              actions: [
-                ElevatedButton(
-                  child: const Text("OK"),
-                  onPressed:
-                      () => Navigator.pushReplacementNamed(context, "/login"),
-                ),
-              ],
-            );
-
-    Platform.isAndroid
-        ? showDialog(
-          context: context,
-          builder: (_) => dialog,
-          barrierDismissible: false,
-        )
-        : showCupertinoDialog(context: context, builder: (_) => dialog);
+            ):*/
+    AlertDialog(
+      title: const Text("Email confirmation"),
+      content: const Text(
+        "Please confirm your email using the link we've sent you. You're going to be redirected to the sign in page.",
+      ),
+      actions: [
+        ElevatedButton(
+          child: const Text("OK"),
+          onPressed: () => Navigator.pushReplacementNamed(context, "/login"),
+        ),
+      ],
+    );
+    // code à décommenter en cas d'exécution sur appareil mobile
+    /*Platform.isAndroid
+    ?
+    showCupertinoDialog(context: context, builder: (_) => dialog) :*/
+    showDialog(
+      context: context,
+      builder: (_) => dialog,
+      barrierDismissible: false,
+    );
   }
 }


### PR DESCRIPTION
Corrected bad duplicate user handling business logic in AuthService.signUp() + removed platform-specific alert dialog display in sign up view which was causing error when running the app on Chrome for example. However, this specific code should be uncommented when running the app on a mobile device.