### PR TITLE
Feature/settings clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ app.*.map.json
 # private files
 ideas.md
 last_checkpoint.md
+errors.txt
 
 # Ignore everything
 /*

--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ last_checkpoint.md
 !/assets/
 !/test/
 !/pubspec.yaml
-!/pubspec.lock
 !/README.md
 !/analysis_options.yaml
 !/devtools_options.yaml

--- a/.metadata
+++ b/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "5874a72aa4c779a02553007c47dacbefba2374dc"
+  revision: "35c388afb57ef061d06a39b537336c87e0e3d1b1"
   channel: "stable"
 
 project_type: app
@@ -13,26 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
     - platform: android
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
     - platform: ios
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
     - platform: linux
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
     - platform: macos
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
     - platform: web
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
     - platform: windows
-      create_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
-      base_revision: 5874a72aa4c779a02553007c47dacbefba2374dc
+      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
 
   # User provided section
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,6 +11,7 @@ analyzer:
     errors:
         avoid_print: ignore
         prefer_function_declarations_over_variables: ignore
+        use_build_context_synchronously: ignore
         #unnecessary_null_comparison: ignore
 include: package:flutter_lints/flutter.yaml
 

--- a/lib/core/models/settings.dart
+++ b/lib/core/models/settings.dart
@@ -1,1 +1,8 @@
-class Settings {}
+class Settings {
+
+  final bool lightMode;
+
+  Settings({
+    required this.lightMode,
+  });
+}

--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -201,20 +201,49 @@ class AuthService {
     }
   }
 
+  Future<bool> _isEmailAvailableForUpdate(String newEmail) async {
+    try {
+      final emailRegex = RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$');
+      if (!emailRegex.hasMatch(newEmail)) {
+        throw Exception("Invalid email format");
+      }
+
+      final response = await _supabaseClient
+          .from('users')
+          .select('user_id')
+          .eq('email', newEmail);
+
+      if (response.isNotEmpty) {
+        if (response.first['user_id'] == _supabaseAuth.currentUser!.id) {
+          return true;
+        }
+        throw Exception(
+          "This email is already associated with another account",
+        );
+      }
+
+      return true;
+    } catch (error) {
+      logger.e("Error checking email availability", error: error);
+      rethrow;
+    }
+  }
+
   Future<UserModel?> updateUser(UserModel user, bool testMode) async {
     try {
+      if (!testMode) {
+        if (user.email != _supabaseAuth.currentUser!.email) {
+          await _isEmailAvailableForUpdate(user.email);
+          await _supabaseAuth.updateUser(UserAttributes(email: user.email));
+          await _supabaseAuth.refreshSession();
+        }
+      }
       final response =
           await _supabaseClient
               .from('users')
               .update(user.toJson())
               .eq('user_id', user.userId)
               .select();
-      if (!testMode) {
-        if (user.email != _supabaseAuth.currentUser!.email) {
-          await _supabaseAuth.updateUser(UserAttributes(email: user.email));
-          await _supabaseAuth.refreshSession();
-        }
-      }
       if (response.isEmpty) {
         throw Exception(
           "User creation failed: user not found/data not returned",
@@ -231,7 +260,6 @@ class AuthService {
     try {
       _supabaseAuth.refreshSession();
       final bool hasVerified = _supabaseAuth.currentUser?.newEmail == null;
-      logger.d("Auth Service: $hasVerified");
       return hasVerified;
     } catch (error) {
       logger.e(

--- a/lib/core/services/friend_service.dart
+++ b/lib/core/services/friend_service.dart
@@ -159,9 +159,54 @@ class FriendService {
 
   Future<FriendshipModel?> sendFriendRequest(String toUserId) async {
     try {
+      final currentUserId = supabaseClient.auth.currentUser!.id;
+
+      final condition1 =
+          'and(user_id_1.eq.$currentUserId,user_id_2.eq.$toUserId)';
+      final condition2 =
+          'and(user_id_1.eq.$toUserId,user_id_2.eq.$currentUserId)';
+
+      final existingFriendship = await supabaseClient
+          .from('friends')
+          .select()
+          .or('$condition1,$condition2')
+          .limit(1);
+
+      if (existingFriendship.isNotEmpty) {
+        final friendship = FriendshipModel.fromJson(existingFriendship.first);
+
+        if (friendship.status == 'rejected') {
+          if (friendship.userId2 == currentUserId) {
+            await supabaseClient
+                .from('friends')
+                .delete()
+                .eq('friendship_id', friendship.friendshipId);
+
+            final response =
+                await supabaseClient.from('friends').insert({
+                  'user_id_1': currentUserId,
+                  'user_id_2': toUserId,
+                  'status': 'pending',
+                }).select();
+
+            return FriendshipModel.fromJson(response.first);
+          } else {
+            await supabaseClient
+                .from('friends')
+                .update({'status': 'pending'})
+                .eq('friendship_id', friendship.friendshipId);
+
+            friendship.status = 'pending';
+            return friendship;
+          }
+        }
+
+        return friendship;
+      }
+
       final response =
           await supabaseClient.from('friends').insert({
-            'user_id_1': supabaseClient.auth.currentUser!.id,
+            'user_id_1': currentUserId,
             'user_id_2': toUserId,
             'status': 'pending',
           }).select();
@@ -182,7 +227,7 @@ class FriendService {
           .eq('user_id_2', toUserId)
           .eq('status', 'pending');
     } catch (e) {
-      log.e("Error canceling friend request: ${e.toString()}", error: e);
+      log.e("Error cancelling friend request: ${e.toString()}", error: e);
       rethrow;
     }
   }

--- a/lib/core/services/settings_service.dart
+++ b/lib/core/services/settings_service.dart
@@ -4,9 +4,11 @@ import 'package:shared_preferences/shared_preferences.dart';
 class SettingsService {
   bool _isLightMode = true;
 
+  bool get isLightMode => _isLightMode;
+
   Future<void> loadSettings() async {
     final prefs = await SharedPreferences.getInstance();
-    _isLightMode = prefs.getBool('light_mode') ?? true; 
+    _isLightMode = prefs.getBool('light_mode') ?? true;
   }
 
   Future<Settings> getAllSettings() async {

--- a/lib/core/services/settings_service.dart
+++ b/lib/core/services/settings_service.dart
@@ -1,0 +1,29 @@
+import 'package:eventura/core/models/settings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SettingsService {
+  bool _isLightMode = true;
+
+  Future<void> loadSettings() async {
+    final prefs = await SharedPreferences.getInstance();
+    _isLightMode = prefs.getBool('light_mode') ?? true; 
+  }
+
+  Future<Settings> getAllSettings() async {
+    final prefs = await SharedPreferences.getInstance();
+    _isLightMode = prefs.getBool('light_mode') ?? true;
+    return Settings(lightMode: _isLightMode);
+  }
+
+  Future<Settings?> toggleLightMode() async {
+    _isLightMode = !_isLightMode;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool('light_mode', _isLightMode);
+      return Settings(lightMode: _isLightMode);
+    } catch (e) {
+      print("Error saving light mode preference: $e");
+      return null;
+    }
+  }
+}

--- a/lib/core/viewmodels/events_list_viewmodel.dart
+++ b/lib/core/viewmodels/events_list_viewmodel.dart
@@ -1,9 +1,9 @@
-// events_list_viewmodel.dart
 import 'dart:async';
 
 import 'package:eventura/core/models/event.dart';
 import 'package:eventura/core/services/event_service.dart';
 import 'package:eventura/core/viewmodels/base_viewmodel.dart';
+
 import 'package:logger/logger.dart';
 
 class EventListViewmodel extends BaseViewmodel {
@@ -28,6 +28,7 @@ class EventListViewmodel extends BaseViewmodel {
 
   Future<void> refreshEvents() async {
     _subscribeToEvents();
+    notifyListeners();
   }
 
   void _subscribeToEvents() {

--- a/lib/core/viewmodels/settings_viewmodel.dart
+++ b/lib/core/viewmodels/settings_viewmodel.dart
@@ -1,3 +1,24 @@
-import 'package:eventura/core/viewmodels/base_viewmodel.dart';
+import 'package:eventura/core/models/settings.dart';
+import 'package:eventura/core/services/settings_service.dart';
+import 'package:flutter/material.dart';
 
-class SettingsViewmodel extends BaseViewmodel{}
+class SettingsViewmodel extends ChangeNotifier {
+  final SettingsService _settingsService = SettingsService();
+
+  late Settings _settings;
+
+  Settings get settings => _settings;
+
+  Future<void> loadSettings() async {
+    _settings = await _settingsService.getAllSettings();
+    notifyListeners();
+  }
+
+  Future<void> toggleDarkMode() async {
+    final updatedSettings = await _settingsService.toggleLightMode();
+    if (updatedSettings != null) {
+      _settings = updatedSettings;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,8 +39,21 @@ Future<void> main() async {
     DeviceOrientation.portraitUp,
     DeviceOrientation.portraitDown,
   ]);
-
-  runApp(MultiProvider(providers: providers, child: Eventura()));
+  final settingsViewModel = SettingsViewmodel(); // Create instance
+  await settingsViewModel.loadSettings(); // Await initial settings load *here
+  runApp(
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider<SettingsViewmodel>.value(
+          value: settingsViewModel,
+        ),
+        ...providers.where(
+          (p) => p is! ChangeNotifierProvider<SettingsViewmodel>,
+        ),
+      ],
+      child: const Eventura(),
+    ),
+  );
 }
 
 final supabase = Supabase.instance.client;
@@ -50,72 +63,69 @@ class Eventura extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final viewModel = Provider.of<SettingsViewmodel>(context);
-    viewModel.loadSettings();
     return Consumer<SettingsViewmodel>(
-      builder:
-          (context, viewmodel, child) => MaterialApp(
-            title: 'Eventura',
-            theme: AppTheme.lightTheme,
-            darkTheme: AppTheme.darkTheme,
-            themeMode:
-                viewmodel.settings.lightMode ? ThemeMode.light : ThemeMode.dark,
-            initialRoute: '/',
-            routes: {
-              '/': (context) => const AuthWrapper(),
-              '/login': (context) => LoginView(),
-              '/signup': (context) => SignupView(),
-              '/reset_password': (context) => ResetPasswordView(),
-              '/welcome': (context) => WelcomeView(),
-              '/home': (context) => HomepageView(),
-              '/create_event': (context) => CreateEventView(),
-              '/event_detail': (context) {
-                final args = ModalRoute.of(context)!.settings.arguments;
-                final eventId = args as int?;
-                if (eventId == null) {
-                  return Scaffold(
-                    appBar: AppBar(title: Text("Error")),
-                    body: Center(
-                      child: Text(
-                        "Error: No Event ID",
-                        style: TextStyle(color: Colors.red),
-                      ),
+      builder: (context, viewmodel, child) {
+        return MaterialApp(
+          title: 'Eventura',
+          theme: AppTheme.lightTheme,
+          darkTheme: AppTheme.darkTheme,
+          themeMode:
+              viewmodel.settings.lightMode ? ThemeMode.light : ThemeMode.dark,
+          initialRoute: '/',
+          routes: {
+            '/': (context) => const AuthWrapper(),
+            '/login': (context) => LoginView(),
+            '/signup': (context) => SignupView(),
+            '/reset_password': (context) => ResetPasswordView(),
+            '/welcome': (context) => WelcomeView(),
+            '/home': (context) => HomepageView(),
+            '/create_event': (context) => CreateEventView(),
+            '/event_detail': (context) {
+              final args = ModalRoute.of(context)!.settings.arguments;
+              final eventId = args as int?;
+              if (eventId == null) {
+                return Scaffold(
+                  appBar: AppBar(title: Text("Error")),
+                  body: Center(
+                    child: Text(
+                      "Error: No Event ID",
+                      style: TextStyle(color: Colors.red),
                     ),
-                  );
-                }
-                return EventDetailView(eventId: eventId);
-              },
-              '/friends': (context) => FriendsView(),
-              '/messages': (context) => MessagesView(),
-              '/profile': (context) {
-                final args = ModalRoute.of(context)!.settings.arguments;
-                final userId = args as String?;
-                final finalUserId = userId ?? supabase.auth.currentUser!.id;
-
-                print('Navigating to profile with userId: $finalUserId');
-
-                return ChangeNotifierProvider(
-                  key: ValueKey(
-                    'profile_route_$finalUserId',
-                  ), // Add a unique key
-                  create:
-                      (context) => ProfileViewmodel(
-                        userService: Provider.of<AuthService>(
-                          context,
-                          listen: false,
-                        ),
-                        userId: finalUserId,
-                      ),
-                  child: ProfileView(userId: finalUserId, fromHome: false),
+                  ),
                 );
-              },
-              '/settings': (context) => SettingsView(),
-              '/about': (context) => AboutUs(),
-              '/contact': (context) => ContactUs(),
-              '/faq': (context) => FAQ(),
-              '/events_list': (context) => EventListView(),
+              }
+              return EventDetailView(eventId: eventId);
             },
-          ),
+            '/friends': (context) => FriendsView(),
+            '/messages': (context) => MessagesView(),
+            '/profile': (context) {
+              final args = ModalRoute.of(context)!.settings.arguments;
+              final userId = args as String?;
+              final finalUserId = userId ?? supabase.auth.currentUser!.id;
+
+              print('Navigating to profile with userId: $finalUserId');
+
+              return ChangeNotifierProvider(
+                key: ValueKey('profile_route_$finalUserId'), // Add a unique key
+                create:
+                    (context) => ProfileViewmodel(
+                      userService: Provider.of<AuthService>(
+                        context,
+                        listen: false,
+                      ),
+                      userId: finalUserId,
+                    ),
+                child: ProfileView(userId: finalUserId, fromHome: false),
+              );
+            },
+            '/settings': (context) => SettingsView(),
+            '/about': (context) => AboutUs(),
+            '/contact': (context) => ContactUs(),
+            '/faq': (context) => FAQ(),
+            '/events_list': (context) => EventListView(),
+          },
+        );
+      },
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:eventura/core/services/auth_service.dart';
 import 'package:eventura/core/viewmodels/profile_viewmodel.dart';
 import 'package:eventura/core/viewmodels/settings_viewmodel.dart';
 import 'package:eventura/providers.dart';
+import 'package:eventura/ui/shared/app_colors.dart';
 import 'package:eventura/ui/shared/app_theme.dart';
 import 'package:eventura/ui/static/about_us.dart';
 import 'package:eventura/ui/static/contact_us.dart';
@@ -22,7 +23,8 @@ import 'package:eventura/ui/widgets/auth_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-// import 'package:flutter_launcher_icons/android.dart';
+import 'package:logger/logger.dart';
+
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -39,8 +41,8 @@ Future<void> main() async {
     DeviceOrientation.portraitUp,
     DeviceOrientation.portraitDown,
   ]);
-  final settingsViewModel = SettingsViewmodel(); // Create instance
-  await settingsViewModel.loadSettings(); // Await initial settings load *here
+  final settingsViewModel = SettingsViewmodel();
+  await settingsViewModel.loadSettings();
   runApp(
     MultiProvider(
       providers: [
@@ -57,6 +59,35 @@ Future<void> main() async {
 }
 
 final supabase = Supabase.instance.client;
+final logger = Logger();
+
+class NavigationObserver extends NavigatorObserver {
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+
+    if (route.settings.name == '/login') {
+      _cancelSubscriptions();
+    }
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    if (newRoute?.settings.name == '/login') {
+      _cancelSubscriptions();
+    }
+  }
+
+  void _cancelSubscriptions() {
+    try {
+      final supabase = Supabase.instance.client;
+      supabase.removeAllChannels();
+    } catch (e) {
+      logger.e("Error clearing subscriptions: $e", error: e);
+    }
+  }
+}
 
 class Eventura extends StatelessWidget {
   const Eventura({super.key});
@@ -72,10 +103,49 @@ class Eventura extends StatelessWidget {
           themeMode:
               viewmodel.settings.lightMode ? ThemeMode.light : ThemeMode.dark,
           initialRoute: '/',
+          navigatorObservers: [NavigationObserver()],
+          onGenerateRoute: (settings) {
+            if (settings.name == '/') {
+              return MaterialPageRoute(
+                settings: settings,
+                builder: (context) => const AuthWrapper(),
+              );
+            }
+
+            if (settings.name == '/event_detail') {
+              final eventId = settings.arguments as int?;
+              if (eventId == null) {
+                return MaterialPageRoute(
+                  settings: settings,
+                  builder:
+                      (context) => Scaffold(
+                        appBar: AppBar(title: const Text("Error")),
+                        body: Center(
+                          child: Padding(
+                            padding: const EdgeInsets.all(16.0),
+                            child: Text(
+                              "Error: No Event ID provided",
+                              style: TextStyle(color: AppColors.errorRed),
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                        ),
+                      ),
+                );
+              }
+              return MaterialPageRoute(
+                settings: settings,
+                builder: (context) => EventDetailView(eventId: eventId),
+              );
+            }
+
+            return null;
+          },
           routes: {
             '/': (context) => const AuthWrapper(),
             '/login': (context) => LoginView(),
             '/signup': (context) => SignupView(),
+
             '/reset_password': (context) => ResetPasswordView(),
             '/welcome': (context) => WelcomeView(),
             '/home': (context) => HomepageView(),
@@ -89,7 +159,7 @@ class Eventura extends StatelessWidget {
                   body: Center(
                     child: Text(
                       "Error: No Event ID",
-                      style: TextStyle(color: Colors.red),
+                      style: TextStyle(color: AppColors.errorRed),
                     ),
                   ),
                 );
@@ -103,10 +173,8 @@ class Eventura extends StatelessWidget {
               final userId = args as String?;
               final finalUserId = userId ?? supabase.auth.currentUser!.id;
 
-              print('Navigating to profile with userId: $finalUserId');
-
               return ChangeNotifierProvider(
-                key: ValueKey('profile_route_$finalUserId'), // Add a unique key
+                key: ValueKey('profile_route_$finalUserId'),
                 create:
                     (context) => ProfileViewmodel(
                       userService: Provider.of<AuthService>(
@@ -115,7 +183,11 @@ class Eventura extends StatelessWidget {
                       ),
                       userId: finalUserId,
                     ),
-                child: ProfileView(userId: finalUserId, fromHome: false),
+                child: ProfileView(
+                  userId: finalUserId,
+                  fromHome: false,
+                  key: ValueKey('profile_$finalUserId'),
+                ),
               );
             },
             '/settings': (context) => SettingsView(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:eventura/core/services/auth_service.dart';
 import 'package:eventura/core/viewmodels/profile_viewmodel.dart';
+import 'package:eventura/core/viewmodels/settings_viewmodel.dart';
 import 'package:eventura/providers.dart';
 import 'package:eventura/ui/shared/app_theme.dart';
 import 'package:eventura/ui/static/about_us.dart';
@@ -21,6 +22,7 @@ import 'package:eventura/ui/widgets/auth_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+// import 'package:flutter_launcher_icons/android.dart';
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -38,7 +40,7 @@ Future<void> main() async {
     DeviceOrientation.portraitDown,
   ]);
 
-  runApp(MultiProvider(providers: providers, child: const Eventura()));
+  runApp(MultiProvider(providers: providers, child: Eventura()));
 }
 
 final supabase = Supabase.instance.client;
@@ -48,59 +50,72 @@ class Eventura extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Eventura',
-      theme: AppTheme().light,
-      initialRoute: '/',
-      routes: {
-        '/': (context) => const AuthWrapper(),
-        '/login': (context) => LoginView(),
-        '/signup': (context) => SignupView(),
-        '/reset_password': (context) => ResetPasswordView(),
-        '/welcome': (context) => WelcomeView(),
-        '/home': (context) => HomepageView(),
-        '/create_event': (context) => CreateEventView(),
-        '/event_detail': (context) {
-          final args = ModalRoute.of(context)!.settings.arguments;
-          final eventId = args as int?;
-          if (eventId == null) {
-            return Scaffold(
-              appBar: AppBar(title: Text("Error")),
-              body: Center(
-                child: Text(
-                  "Error: No Event ID",
-                  style: TextStyle(color: Colors.red),
-                ),
-              ),
-            );
-          }
-          return EventDetailView(eventId: eventId);
-        },
-        '/friends': (context) => FriendsView(),
-        '/messages': (context) => MessagesView(),
-        '/profile': (context) {
-          final args = ModalRoute.of(context)!.settings.arguments;
-          final userId = args as String?;
-          final finalUserId = userId ?? supabase.auth.currentUser!.id;
+    final viewModel = Provider.of<SettingsViewmodel>(context);
+    viewModel.loadSettings();
+    return Consumer<SettingsViewmodel>(
+      builder:
+          (context, viewmodel, child) => MaterialApp(
+            title: 'Eventura',
+            theme: AppTheme.lightTheme,
+            darkTheme: AppTheme.darkTheme,
+            themeMode:
+                viewmodel.settings.lightMode ? ThemeMode.light : ThemeMode.dark,
+            initialRoute: '/',
+            routes: {
+              '/': (context) => const AuthWrapper(),
+              '/login': (context) => LoginView(),
+              '/signup': (context) => SignupView(),
+              '/reset_password': (context) => ResetPasswordView(),
+              '/welcome': (context) => WelcomeView(),
+              '/home': (context) => HomepageView(),
+              '/create_event': (context) => CreateEventView(),
+              '/event_detail': (context) {
+                final args = ModalRoute.of(context)!.settings.arguments;
+                final eventId = args as int?;
+                if (eventId == null) {
+                  return Scaffold(
+                    appBar: AppBar(title: Text("Error")),
+                    body: Center(
+                      child: Text(
+                        "Error: No Event ID",
+                        style: TextStyle(color: Colors.red),
+                      ),
+                    ),
+                  );
+                }
+                return EventDetailView(eventId: eventId);
+              },
+              '/friends': (context) => FriendsView(),
+              '/messages': (context) => MessagesView(),
+              '/profile': (context) {
+                final args = ModalRoute.of(context)!.settings.arguments;
+                final userId = args as String?;
+                final finalUserId = userId ?? supabase.auth.currentUser!.id;
 
-          print('Navigating to profile with userId: $finalUserId');
+                print('Navigating to profile with userId: $finalUserId');
 
-          return ChangeNotifierProvider(
-            key: ValueKey('profile_route_$finalUserId'), // Add a unique key
-            create:
-                (context) => ProfileViewmodel(
-                  userService: Provider.of<AuthService>(context, listen: false),
-                  userId: finalUserId,
-                ),
-            child: ProfileView(userId: finalUserId, fromHome: false),
-          );
-        },
-        '/settings': (context) => SettingsView(),
-        '/about': (context) => AboutUs(),
-        '/contact': (context) => ContactUs(),
-        '/faq': (context) => FAQ(),
-        '/events_list': (context) => EventListView(),
-      },
+                return ChangeNotifierProvider(
+                  key: ValueKey(
+                    'profile_route_$finalUserId',
+                  ), // Add a unique key
+                  create:
+                      (context) => ProfileViewmodel(
+                        userService: Provider.of<AuthService>(
+                          context,
+                          listen: false,
+                        ),
+                        userId: finalUserId,
+                      ),
+                  child: ProfileView(userId: finalUserId, fromHome: false),
+                );
+              },
+              '/settings': (context) => SettingsView(),
+              '/about': (context) => AboutUs(),
+              '/contact': (context) => ContactUs(),
+              '/faq': (context) => FAQ(),
+              '/events_list': (context) => EventListView(),
+            },
+          ),
     );
   }
 }

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -1,4 +1,3 @@
-// providers.dart
 import 'package:eventura/core/services/auth_service.dart';
 import 'package:eventura/core/services/event_service.dart';
 import 'package:eventura/core/services/friend_service.dart';
@@ -10,7 +9,6 @@ import 'package:eventura/core/viewmodels/event_viewmodel.dart';
 import 'package:eventura/core/viewmodels/events_list_viewmodel.dart';
 import 'package:eventura/core/viewmodels/friends_viewmodel.dart';
 import 'package:eventura/core/viewmodels/messages_list_viewmodel.dart';
-// import 'package:eventura/core/viewmodels/profile_viewmodel.dart';
 import 'package:eventura/core/viewmodels/settings_viewmodel.dart';
 import 'package:eventura/ui/shared/is_editing_profile.dart';
 import 'package:provider/provider.dart';

--- a/lib/ui/shared/app_colors.dart
+++ b/lib/ui/shared/app_colors.dart
@@ -20,8 +20,9 @@ class AppColors {
   static const Color onSuccessGreen = Colors.white;
 
   // Secondary Action / Subtle (Grey for sign out, some text)
-  static const Color secondaryGrey = Color(0xFF757575); // Grey 600
-  static const Color onSecondaryGrey = Colors.white;
+  static const Color secondaryGrey = Color(0xFFF2F2F2);
+  static const Color onSecondaryGrey = Color(0xFF4D4D4D);
+  static const Color onSecondaryGreyVariant = Color(0xFFA6A6A6);
 
   // Link Color (DeepPurple used for clickable text spans)
   static const Color linkPurple = primaryPurple;

--- a/lib/ui/shared/app_colors.dart
+++ b/lib/ui/shared/app_colors.dart
@@ -1,1 +1,28 @@
-class AppColors {}
+import 'package:flutter/material.dart';
+
+class AppColors {
+  // Primary Accent (Purple used for main actions, switches)
+  static const Color primaryPurple = Color(0xFF673AB7); // Deep Purple 500
+  static const Color primaryPurpleLight = Color(0xFFD1C4E9); // Deep Purple 100
+  static const Color primaryPurpleDark = Color(0xFF311B92); // Deep Purple 900
+
+  // Error / Destructive (Red used for errors, delete/refuse)
+  static const Color errorRed = Color(0xFFD32F2F); // Red 700
+  static const Color errorRedShade300 = Color(0xFFE57373);
+  static const Color onErrorRed = Colors.white;
+
+  // Warning (Orange for email verification)
+  static const Color warningOrange = Color(0xFFFFA000); // Amber 700
+  static const Color onWarningOrange = Colors.black;
+
+  // Success (Green for accept friend request)
+  static const Color successGreen = Color(0xFF388E3C); // Green 700
+  static const Color onSuccessGreen = Colors.white;
+
+  // Secondary Action / Subtle (Grey for sign out, some text)
+  static const Color secondaryGrey = Color(0xFF757575); // Grey 600
+  static const Color onSecondaryGrey = Colors.white;
+
+  // Link Color (DeepPurple used for clickable text spans)
+  static const Color linkPurple = primaryPurple;
+}

--- a/lib/ui/shared/app_theme.dart
+++ b/lib/ui/shared/app_theme.dart
@@ -9,7 +9,7 @@ class AppTheme {
       useMaterial3: true,
     ); // Start with M3 light defaults
     final lightColorScheme = ColorScheme.fromSeed(
-      seedColor: AppColors.primaryPurple, // Use your primary color as the seed
+      seedColor: AppColors.primaryPurple,
       brightness: Brightness.light,
 
       primary: AppColors.primaryPurple,
@@ -73,19 +73,19 @@ class AppTheme {
           if (states.contains(WidgetState.selected)) {
             return lightColorScheme.primary;
           }
-          return null; // Use default
+          return null;
         }),
         trackColor: WidgetStateProperty.resolveWith<Color?>((states) {
           if (states.contains(WidgetState.selected)) {
-            return lightColorScheme.primary.withOpacity(0.5);
+            return lightColorScheme.primary.withValues(alpha: 0.5);
           }
-          return null; // Use default
+          return null;
         }),
         trackOutlineColor: WidgetStateProperty.resolveWith<Color?>((states) {
           if (states.contains(WidgetState.selected)) {
-            return Colors.transparent; // Optional: remove outline when selected
+            return Colors.transparent;
           }
-          return null; // Use default outline color otherwise
+          return null;
         }),
       ),
       snackBarTheme: SnackBarThemeData(
@@ -114,11 +114,8 @@ class AppTheme {
         // Customize specific text styles if needed
         bodyMedium: GoogleFonts.lato(color: lightColorScheme.onSurface),
         titleMedium: GoogleFonts.lato(color: lightColorScheme.onSurface),
-        labelLarge: GoogleFonts.lato(
-          fontWeight: FontWeight.bold,
-        ), // Often used in buttons
+        labelLarge: GoogleFonts.lato(fontWeight: FontWeight.bold),
       ),
-      // Add other component themes as needed (CardTheme, ChipTheme, etc.)
     );
   }
 
@@ -128,15 +125,11 @@ class AppTheme {
       useMaterial3: true,
     ); // Start with M3 dark defaults
     final darkColorScheme = ColorScheme.fromSeed(
-      seedColor: AppColors.primaryPurple, // Use the same seed color
+      seedColor: AppColors.primaryPurple,
       brightness: Brightness.dark,
       // Override specific roles if needed
-      primary:
-          AppColors
-              .primaryPurpleLight, // Often use a lighter primary in dark mode
-      error: AppColors.errorRedShade300, // Use a lighter red for contrast
-      // background: AppColors._darkBackground, // Or let fromSeed handle defaults
-      // surface: AppColors._darkSurface, // Or let fromSeed handle defaults
+      primary: AppColors.primaryPurpleLight,
+      error: AppColors.errorRedShade300,
     );
 
     return baseTheme.copyWith(
@@ -144,9 +137,9 @@ class AppTheme {
       // --- Component Themes (Dark Variants) ---
       scaffoldBackgroundColor: darkColorScheme.surface,
       appBarTheme: AppBarTheme(
-        backgroundColor: darkColorScheme.surface, // Common dark pattern
+        backgroundColor: darkColorScheme.surface,
         foregroundColor: darkColorScheme.onSurface,
-        elevation: 0, // Often less elevation in dark app bars
+        elevation: 0,
         titleTextStyle: GoogleFonts.lato(
           fontSize: 20,
           fontWeight: FontWeight.bold,
@@ -193,19 +186,19 @@ class AppTheme {
           if (states.contains(WidgetState.selected)) {
             return darkColorScheme.primary;
           }
-          return null; // Use default
+          return null;
         }),
         trackColor: WidgetStateProperty.resolveWith<Color?>((states) {
           if (states.contains(WidgetState.selected)) {
-            return darkColorScheme.primary.withOpacity(0.5);
+            return darkColorScheme.primary.withValues(alpha: 0.5);
           }
-          return null; // Use default
+          return null;
         }),
         trackOutlineColor: WidgetStateProperty.resolveWith<Color?>((states) {
           if (states.contains(WidgetState.selected)) {
-            return Colors.transparent; // Optional: remove outline when selected
+            return Colors.transparent;
           }
-          return null; // Use default outline color otherwise
+          return null;
         }),
       ),
       snackBarTheme: SnackBarThemeData(
@@ -234,11 +227,8 @@ class AppTheme {
         // Customize specific text styles if needed
         bodyMedium: GoogleFonts.lato(color: darkColorScheme.onSurface),
         titleMedium: GoogleFonts.lato(color: darkColorScheme.onSurface),
-        labelLarge: GoogleFonts.lato(
-          fontWeight: FontWeight.bold,
-        ), // Often used in buttons
+        labelLarge: GoogleFonts.lato(fontWeight: FontWeight.bold),
       ),
-      // Add other component themes as needed
     );
   }
 }

--- a/lib/ui/shared/app_theme.dart
+++ b/lib/ui/shared/app_theme.dart
@@ -3,71 +3,136 @@ import 'package:google_fonts/google_fonts.dart';
 import 'app_colors.dart';
 
 class AppTheme {
-  // --- Light Theme ---
+  static const double buttonBorderRadius = 12.0;
+  static const double cardBorderRadius = 12.0;
+  static const double inputBorderRadius = 8.0;
+
+  static const double buttonFontSize = 16.0;
+  static const FontWeight buttonFontWeight = FontWeight.bold;
+
   static ThemeData get lightTheme {
-    final baseTheme = ThemeData.light(
-      useMaterial3: true,
-    ); // Start with M3 light defaults
+    final baseTheme = ThemeData.light(useMaterial3: true);
     final lightColorScheme = ColorScheme.fromSeed(
       seedColor: AppColors.primaryPurple,
       brightness: Brightness.light,
-
       primary: AppColors.primaryPurple,
       error: AppColors.errorRed,
     );
 
+    final baseTextTheme = GoogleFonts.latoTextTheme(baseTheme.textTheme);
+
     return baseTheme.copyWith(
       colorScheme: lightColorScheme,
-      // --- Component Themes ---
       scaffoldBackgroundColor: lightColorScheme.surface,
+
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: lightColorScheme.primary,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          textStyle: TextStyle(
+            fontWeight: buttonFontWeight,
+            fontSize: buttonFontSize,
+          ),
+        ),
+      ),
+
+      listTileTheme: ListTileThemeData(
+        tileColor: null,
+        selectedTileColor: lightColorScheme.primaryContainer.withValues(
+          alpha: 0.4,
+        ),
+        iconColor: lightColorScheme.onSurfaceVariant,
+        textColor: lightColorScheme.onSurface,
+        titleTextStyle: TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.w500,
+          color: lightColorScheme.onSurface,
+        ),
+        subtitleTextStyle: TextStyle(
+          fontSize: 14,
+          color: lightColorScheme.onSurfaceVariant,
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16.0,
+          vertical: 8.0,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(cardBorderRadius),
+        ),
+      ),
+
+      cardTheme: CardTheme(
+        color: lightColorScheme.surface,
+        elevation: 1,
+        margin: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 4.0),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(cardBorderRadius),
+        ),
+      ),
+
       appBarTheme: AppBarTheme(
         backgroundColor: lightColorScheme.primary,
         foregroundColor: lightColorScheme.onPrimary,
         elevation: 4.0,
-        titleTextStyle: GoogleFonts.lato(
-          // Example using Google Fonts
+        titleTextStyle: TextStyle(
           fontSize: 20,
           fontWeight: FontWeight.bold,
           color: lightColorScheme.onPrimary,
         ),
       ),
+
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
-          backgroundColor:
-              lightColorScheme.primary, // Default button background
-          foregroundColor:
-              lightColorScheme.onPrimary, // Default button text/icon
-          textStyle: GoogleFonts.lato(fontWeight: FontWeight.bold),
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          backgroundColor: lightColorScheme.primary,
+          foregroundColor: lightColorScheme.onPrimary,
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 15),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(buttonBorderRadius),
+          ),
+          textStyle: TextStyle(
+            fontWeight: buttonFontWeight,
+            fontSize: buttonFontSize,
+            overflow: TextOverflow.ellipsis,
+          ),
+          elevation: 3.0,
         ),
       ),
+
       inputDecorationTheme: InputDecorationTheme(
         border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(inputBorderRadius),
           borderSide: BorderSide(color: lightColorScheme.outline),
         ),
         enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(inputBorderRadius),
           borderSide: BorderSide(color: lightColorScheme.outline),
         ),
         focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(inputBorderRadius),
           borderSide: BorderSide(color: lightColorScheme.primary, width: 2),
         ),
         errorBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(inputBorderRadius),
           borderSide: BorderSide(color: lightColorScheme.error, width: 1.5),
         ),
         focusedErrorBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(inputBorderRadius),
           borderSide: BorderSide(color: lightColorScheme.error, width: 2),
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 16,
         ),
         labelStyle: TextStyle(color: lightColorScheme.onSurfaceVariant),
         floatingLabelStyle: TextStyle(color: lightColorScheme.primary),
-        errorStyle: TextStyle(color: lightColorScheme.error, fontSize: 12),
-        errorMaxLines: 2, // Allow error text to wrap
+        errorStyle: TextStyle(
+          color: lightColorScheme.error,
+          fontSize: 12,
+          fontWeight: FontWeight.w500,
+        ),
+        errorMaxLines: 4,
       ),
+
       switchTheme: SwitchThemeData(
         thumbColor: WidgetStateProperty.resolveWith<Color?>((states) {
           if (states.contains(WidgetState.selected)) {
@@ -88,99 +153,262 @@ class AppTheme {
           return null;
         }),
       ),
+
       snackBarTheme: SnackBarThemeData(
-        // Default style (errors will override background color)
         backgroundColor: lightColorScheme.inverseSurface,
         contentTextStyle: TextStyle(color: lightColorScheme.onInverseSurface),
         actionTextColor: lightColorScheme.inversePrimary,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        behavior: SnackBarBehavior.floating,
       ),
+
       dialogTheme: DialogTheme(
-        backgroundColor: lightColorScheme.surface,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        backgroundColor: lightColorScheme.surfaceContainerHighest,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         titleTextStyle: TextStyle(
-          color: lightColorScheme.onSurface,
           fontSize: 20,
           fontWeight: FontWeight.bold,
+          color: lightColorScheme.onSurface,
         ),
         contentTextStyle: TextStyle(
-          color: lightColorScheme.onSurfaceVariant,
           fontSize: 16,
+          color: lightColorScheme.onSurface,
         ),
       ),
+
       progressIndicatorTheme: ProgressIndicatorThemeData(
         color: lightColorScheme.primary,
+        circularTrackColor: lightColorScheme.primary.withValues(alpha: 0.2),
       ),
-      textTheme: GoogleFonts.latoTextTheme(baseTheme.textTheme).copyWith(
-        // Customize specific text styles if needed
-        bodyMedium: GoogleFonts.lato(color: lightColorScheme.onSurface),
-        titleMedium: GoogleFonts.lato(color: lightColorScheme.onSurface),
-        labelLarge: GoogleFonts.lato(fontWeight: FontWeight.bold),
+
+      textSelectionTheme: TextSelectionThemeData(
+        cursorColor: lightColorScheme.primary,
+        selectionColor: lightColorScheme.primary.withValues(alpha: 0.4),
+        selectionHandleColor: lightColorScheme.primary,
+      ),
+
+      drawerTheme: DrawerThemeData(
+        backgroundColor: lightColorScheme.surface,
+        scrimColor: lightColorScheme.scrim.withValues(alpha: 0.6),
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.only(
+            topRight: Radius.circular(16),
+            bottomRight: Radius.circular(16),
+          ),
+        ),
+      ),
+
+      textTheme: baseTextTheme.copyWith(
+        displayLarge: baseTextTheme.displayLarge?.copyWith(
+          fontSize: 57,
+          color: lightColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+        ),
+        displayMedium: baseTextTheme.displayMedium?.copyWith(
+          fontSize: 45,
+          color: lightColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+        ),
+        displaySmall: baseTextTheme.displaySmall?.copyWith(
+          fontSize: 36,
+          color: lightColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+        ),
+        headlineLarge: baseTextTheme.headlineLarge?.copyWith(
+          fontSize: 32,
+          color: lightColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+        ),
+        headlineMedium: baseTextTheme.headlineMedium?.copyWith(
+          fontSize: 28,
+          color: lightColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+        ),
+        headlineSmall: baseTextTheme.headlineSmall?.copyWith(
+          fontSize: 24,
+          color: lightColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+        ),
+        titleLarge: baseTextTheme.titleLarge?.copyWith(
+          fontSize: 22,
+          color: lightColorScheme.onSurface,
+          fontWeight: FontWeight.w500,
+        ),
+        titleMedium: baseTextTheme.titleMedium?.copyWith(
+          fontSize: 16,
+          color: lightColorScheme.onSurface,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.15,
+        ),
+        titleSmall: baseTextTheme.titleSmall?.copyWith(
+          fontSize: 14,
+          color: lightColorScheme.onSurface,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.1,
+        ),
+        labelLarge: baseTextTheme.labelLarge?.copyWith(
+          fontSize: 14,
+          color: lightColorScheme.onSurface,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.1,
+        ),
+        labelMedium: baseTextTheme.labelMedium?.copyWith(
+          fontSize: 12,
+          color: lightColorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.5,
+        ),
+        labelSmall: baseTextTheme.labelSmall?.copyWith(
+          fontSize: 11,
+          color: lightColorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.5,
+        ),
+        bodyLarge: baseTextTheme.bodyLarge?.copyWith(
+          fontSize: 16,
+          color: lightColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+          letterSpacing: 0.5,
+        ),
+        bodyMedium: baseTextTheme.bodyMedium?.copyWith(
+          fontSize: 14,
+          color: lightColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+          letterSpacing: 0.25,
+        ),
+        bodySmall: baseTextTheme.bodySmall?.copyWith(
+          fontSize: 12,
+          color: lightColorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w400,
+          letterSpacing: 0.4,
+        ),
       ),
     );
   }
 
-  // --- Dark Theme ---
   static ThemeData get darkTheme {
-    final baseTheme = ThemeData.dark(
-      useMaterial3: true,
-    ); // Start with M3 dark defaults
+    final baseTheme = ThemeData.dark(useMaterial3: true);
     final darkColorScheme = ColorScheme.fromSeed(
       seedColor: AppColors.primaryPurple,
       brightness: Brightness.dark,
-      // Override specific roles if needed
       primary: AppColors.primaryPurpleLight,
       error: AppColors.errorRedShade300,
     );
 
+    final baseTextTheme = GoogleFonts.latoTextTheme(baseTheme.textTheme);
+
     return baseTheme.copyWith(
       colorScheme: darkColorScheme,
-      // --- Component Themes (Dark Variants) ---
       scaffoldBackgroundColor: darkColorScheme.surface,
+
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: darkColorScheme.primary,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          textStyle: TextStyle(
+            fontWeight: buttonFontWeight,
+            fontSize: buttonFontSize,
+          ),
+        ),
+      ),
+
+      listTileTheme: ListTileThemeData(
+        tileColor: null,
+        selectedTileColor: darkColorScheme.primaryContainer.withValues(
+          alpha: 0.4,
+        ),
+        iconColor: darkColorScheme.onSurfaceVariant,
+        textColor: darkColorScheme.onSurface,
+        titleTextStyle: TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.w500,
+          color: darkColorScheme.onSurface,
+        ),
+        subtitleTextStyle: TextStyle(
+          fontSize: 14,
+          color: darkColorScheme.onSurfaceVariant,
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16.0,
+          vertical: 8.0,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(cardBorderRadius),
+        ),
+      ),
+
+      cardTheme: CardTheme(
+        color: darkColorScheme.surfaceContainerHighest,
+        elevation: 6,
+        margin: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 4.0),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(cardBorderRadius),
+        ),
+      ),
+
       appBarTheme: AppBarTheme(
         backgroundColor: darkColorScheme.surface,
         foregroundColor: darkColorScheme.onSurface,
         elevation: 0,
-        titleTextStyle: GoogleFonts.lato(
+        titleTextStyle: TextStyle(
           fontSize: 20,
           fontWeight: FontWeight.bold,
           color: darkColorScheme.onSurface,
         ),
       ),
+
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
           backgroundColor: darkColorScheme.primary,
-          foregroundColor: darkColorScheme.onPrimary, // Text color on primary
-          textStyle: GoogleFonts.lato(fontWeight: FontWeight.bold),
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          foregroundColor: darkColorScheme.onPrimary,
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 15),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(buttonBorderRadius),
+          ),
+          textStyle: TextStyle(
+            fontWeight: buttonFontWeight,
+            fontSize: buttonFontSize,
+            overflow: TextOverflow.ellipsis,
+          ),
+          elevation: 3.0,
         ),
       ),
+
       inputDecorationTheme: InputDecorationTheme(
         border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(inputBorderRadius),
           borderSide: BorderSide(color: darkColorScheme.outline),
         ),
         enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(inputBorderRadius),
           borderSide: BorderSide(color: darkColorScheme.outline),
         ),
         focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(inputBorderRadius),
           borderSide: BorderSide(color: darkColorScheme.primary, width: 2),
         ),
         errorBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(inputBorderRadius),
           borderSide: BorderSide(color: darkColorScheme.error, width: 1.5),
         ),
         focusedErrorBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(inputBorderRadius),
           borderSide: BorderSide(color: darkColorScheme.error, width: 2),
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 16,
         ),
         labelStyle: TextStyle(color: darkColorScheme.onSurfaceVariant),
         floatingLabelStyle: TextStyle(color: darkColorScheme.primary),
-        errorStyle: TextStyle(color: darkColorScheme.error, fontSize: 12),
-        errorMaxLines: 2, // Allow error text to wrap
+        errorStyle: TextStyle(
+          color: darkColorScheme.error,
+          fontSize: 12,
+          fontWeight: FontWeight.w500,
+        ),
+        errorMaxLines: 4,
       ),
+
       switchTheme: SwitchThemeData(
         thumbColor: WidgetStateProperty.resolveWith<Color?>((states) {
           if (states.contains(WidgetState.selected)) {
@@ -201,33 +429,135 @@ class AppTheme {
           return null;
         }),
       ),
+
       snackBarTheme: SnackBarThemeData(
-        // Default style (errors will override background color)
         backgroundColor: darkColorScheme.inverseSurface,
         contentTextStyle: TextStyle(color: darkColorScheme.onInverseSurface),
         actionTextColor: darkColorScheme.inversePrimary,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        behavior: SnackBarBehavior.floating,
       ),
+
       dialogTheme: DialogTheme(
         backgroundColor: darkColorScheme.surface,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         titleTextStyle: TextStyle(
-          color: darkColorScheme.onSurface,
           fontSize: 20,
           fontWeight: FontWeight.bold,
+          color: darkColorScheme.onSurface,
         ),
         contentTextStyle: TextStyle(
-          color: darkColorScheme.onSurfaceVariant,
           fontSize: 16,
+          color: darkColorScheme.onSurface,
         ),
       ),
+
       progressIndicatorTheme: ProgressIndicatorThemeData(
         color: darkColorScheme.primary,
+        circularTrackColor: darkColorScheme.primary.withValues(alpha: 0.2),
       ),
-      textTheme: GoogleFonts.latoTextTheme(baseTheme.textTheme).copyWith(
-        // Customize specific text styles if needed
-        bodyMedium: GoogleFonts.lato(color: darkColorScheme.onSurface),
-        titleMedium: GoogleFonts.lato(color: darkColorScheme.onSurface),
-        labelLarge: GoogleFonts.lato(fontWeight: FontWeight.bold),
+
+      textSelectionTheme: TextSelectionThemeData(
+        cursorColor: darkColorScheme.primary,
+        selectionColor: darkColorScheme.primary.withValues(alpha: 0.4),
+        selectionHandleColor: darkColorScheme.primary,
+      ),
+
+      drawerTheme: DrawerThemeData(
+        backgroundColor: darkColorScheme.surface,
+        scrimColor: darkColorScheme.scrim.withValues(alpha: 0.6),
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.only(
+            topRight: Radius.circular(16),
+            bottomRight: Radius.circular(16),
+          ),
+        ),
+      ),
+
+      textTheme: baseTextTheme.copyWith(
+        displayLarge: baseTextTheme.displayLarge?.copyWith(
+          fontSize: 57,
+          color: darkColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+        ),
+        displayMedium: baseTextTheme.displayMedium?.copyWith(
+          fontSize: 45,
+          color: darkColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+        ),
+        displaySmall: baseTextTheme.displaySmall?.copyWith(
+          fontSize: 36,
+          color: darkColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+        ),
+        headlineLarge: baseTextTheme.headlineLarge?.copyWith(
+          fontSize: 32,
+          color: darkColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+        ),
+        headlineMedium: baseTextTheme.headlineMedium?.copyWith(
+          fontSize: 28,
+          color: darkColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+        ),
+        headlineSmall: baseTextTheme.headlineSmall?.copyWith(
+          fontSize: 24,
+          color: darkColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+        ),
+        titleLarge: baseTextTheme.titleLarge?.copyWith(
+          fontSize: 22,
+          color: darkColorScheme.onSurface,
+          fontWeight: FontWeight.w500,
+        ),
+        titleMedium: baseTextTheme.titleMedium?.copyWith(
+          fontSize: 16,
+          color: darkColorScheme.onSurface,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.15,
+        ),
+        titleSmall: baseTextTheme.titleSmall?.copyWith(
+          fontSize: 14,
+          color: darkColorScheme.onSurface,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.1,
+        ),
+        labelLarge: baseTextTheme.labelLarge?.copyWith(
+          fontSize: 14,
+          color: darkColorScheme.onSurface,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.1,
+        ),
+        labelMedium: baseTextTheme.labelMedium?.copyWith(
+          fontSize: 12,
+          color: darkColorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.5,
+        ),
+        labelSmall: baseTextTheme.labelSmall?.copyWith(
+          fontSize: 11,
+          color: darkColorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.5,
+        ),
+        bodyLarge: baseTextTheme.bodyLarge?.copyWith(
+          fontSize: 16,
+          color: darkColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+          letterSpacing: 0.5,
+        ),
+        bodyMedium: baseTextTheme.bodyMedium?.copyWith(
+          fontSize: 14,
+          color: darkColorScheme.onSurface,
+          fontWeight: FontWeight.w400,
+          letterSpacing: 0.25,
+        ),
+        bodySmall: baseTextTheme.bodySmall?.copyWith(
+          fontSize: 12,
+          color: darkColorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w400,
+          letterSpacing: 0.4,
+        ),
       ),
     );
   }

--- a/lib/ui/shared/app_theme.dart
+++ b/lib/ui/shared/app_theme.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 
 class AppTheme {
-  final ThemeData lightTheme = ThemeData(
-    brightness: Brightness.light,
-    primaryColor: Colors.blue, 
-    // TODO: add other properties
-  );
-  ThemeData get light => lightTheme;
+  ThemeData get light => ThemeData(
+        brightness: Brightness.light,
+        primarySwatch: Colors.deepPurple,
+      );
+
+  ThemeData get dark => ThemeData(
+        brightness: Brightness.dark,
+        primarySwatch: Colors.deepPurple,
+      );
 }

--- a/lib/ui/shared/app_theme.dart
+++ b/lib/ui/shared/app_theme.dart
@@ -1,13 +1,244 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'app_colors.dart';
 
 class AppTheme {
-  ThemeData get light => ThemeData(
-        brightness: Brightness.light,
-        primarySwatch: Colors.deepPurple,
-      );
+  // --- Light Theme ---
+  static ThemeData get lightTheme {
+    final baseTheme = ThemeData.light(
+      useMaterial3: true,
+    ); // Start with M3 light defaults
+    final lightColorScheme = ColorScheme.fromSeed(
+      seedColor: AppColors.primaryPurple, // Use your primary color as the seed
+      brightness: Brightness.light,
 
-  ThemeData get dark => ThemeData(
-        brightness: Brightness.dark,
-        primarySwatch: Colors.deepPurple,
-      );
+      primary: AppColors.primaryPurple,
+      error: AppColors.errorRed,
+    );
+
+    return baseTheme.copyWith(
+      colorScheme: lightColorScheme,
+      // --- Component Themes ---
+      scaffoldBackgroundColor: lightColorScheme.surface,
+      appBarTheme: AppBarTheme(
+        backgroundColor: lightColorScheme.primary,
+        foregroundColor: lightColorScheme.onPrimary,
+        elevation: 4.0,
+        titleTextStyle: GoogleFonts.lato(
+          // Example using Google Fonts
+          fontSize: 20,
+          fontWeight: FontWeight.bold,
+          color: lightColorScheme.onPrimary,
+        ),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor:
+              lightColorScheme.primary, // Default button background
+          foregroundColor:
+              lightColorScheme.onPrimary, // Default button text/icon
+          textStyle: GoogleFonts.lato(fontWeight: FontWeight.bold),
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: lightColorScheme.outline),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: lightColorScheme.outline),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: lightColorScheme.primary, width: 2),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: lightColorScheme.error, width: 1.5),
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: lightColorScheme.error, width: 2),
+        ),
+        labelStyle: TextStyle(color: lightColorScheme.onSurfaceVariant),
+        floatingLabelStyle: TextStyle(color: lightColorScheme.primary),
+        errorStyle: TextStyle(color: lightColorScheme.error, fontSize: 12),
+        errorMaxLines: 2, // Allow error text to wrap
+      ),
+      switchTheme: SwitchThemeData(
+        thumbColor: WidgetStateProperty.resolveWith<Color?>((states) {
+          if (states.contains(WidgetState.selected)) {
+            return lightColorScheme.primary;
+          }
+          return null; // Use default
+        }),
+        trackColor: WidgetStateProperty.resolveWith<Color?>((states) {
+          if (states.contains(WidgetState.selected)) {
+            return lightColorScheme.primary.withOpacity(0.5);
+          }
+          return null; // Use default
+        }),
+        trackOutlineColor: WidgetStateProperty.resolveWith<Color?>((states) {
+          if (states.contains(WidgetState.selected)) {
+            return Colors.transparent; // Optional: remove outline when selected
+          }
+          return null; // Use default outline color otherwise
+        }),
+      ),
+      snackBarTheme: SnackBarThemeData(
+        // Default style (errors will override background color)
+        backgroundColor: lightColorScheme.inverseSurface,
+        contentTextStyle: TextStyle(color: lightColorScheme.onInverseSurface),
+        actionTextColor: lightColorScheme.inversePrimary,
+      ),
+      dialogTheme: DialogTheme(
+        backgroundColor: lightColorScheme.surface,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        titleTextStyle: TextStyle(
+          color: lightColorScheme.onSurface,
+          fontSize: 20,
+          fontWeight: FontWeight.bold,
+        ),
+        contentTextStyle: TextStyle(
+          color: lightColorScheme.onSurfaceVariant,
+          fontSize: 16,
+        ),
+      ),
+      progressIndicatorTheme: ProgressIndicatorThemeData(
+        color: lightColorScheme.primary,
+      ),
+      textTheme: GoogleFonts.latoTextTheme(baseTheme.textTheme).copyWith(
+        // Customize specific text styles if needed
+        bodyMedium: GoogleFonts.lato(color: lightColorScheme.onSurface),
+        titleMedium: GoogleFonts.lato(color: lightColorScheme.onSurface),
+        labelLarge: GoogleFonts.lato(
+          fontWeight: FontWeight.bold,
+        ), // Often used in buttons
+      ),
+      // Add other component themes as needed (CardTheme, ChipTheme, etc.)
+    );
+  }
+
+  // --- Dark Theme ---
+  static ThemeData get darkTheme {
+    final baseTheme = ThemeData.dark(
+      useMaterial3: true,
+    ); // Start with M3 dark defaults
+    final darkColorScheme = ColorScheme.fromSeed(
+      seedColor: AppColors.primaryPurple, // Use the same seed color
+      brightness: Brightness.dark,
+      // Override specific roles if needed
+      primary:
+          AppColors
+              .primaryPurpleLight, // Often use a lighter primary in dark mode
+      error: AppColors.errorRedShade300, // Use a lighter red for contrast
+      // background: AppColors._darkBackground, // Or let fromSeed handle defaults
+      // surface: AppColors._darkSurface, // Or let fromSeed handle defaults
+    );
+
+    return baseTheme.copyWith(
+      colorScheme: darkColorScheme,
+      // --- Component Themes (Dark Variants) ---
+      scaffoldBackgroundColor: darkColorScheme.surface,
+      appBarTheme: AppBarTheme(
+        backgroundColor: darkColorScheme.surface, // Common dark pattern
+        foregroundColor: darkColorScheme.onSurface,
+        elevation: 0, // Often less elevation in dark app bars
+        titleTextStyle: GoogleFonts.lato(
+          fontSize: 20,
+          fontWeight: FontWeight.bold,
+          color: darkColorScheme.onSurface,
+        ),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: darkColorScheme.primary,
+          foregroundColor: darkColorScheme.onPrimary, // Text color on primary
+          textStyle: GoogleFonts.lato(fontWeight: FontWeight.bold),
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: darkColorScheme.outline),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: darkColorScheme.outline),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: darkColorScheme.primary, width: 2),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: darkColorScheme.error, width: 1.5),
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: darkColorScheme.error, width: 2),
+        ),
+        labelStyle: TextStyle(color: darkColorScheme.onSurfaceVariant),
+        floatingLabelStyle: TextStyle(color: darkColorScheme.primary),
+        errorStyle: TextStyle(color: darkColorScheme.error, fontSize: 12),
+        errorMaxLines: 2, // Allow error text to wrap
+      ),
+      switchTheme: SwitchThemeData(
+        thumbColor: WidgetStateProperty.resolveWith<Color?>((states) {
+          if (states.contains(WidgetState.selected)) {
+            return darkColorScheme.primary;
+          }
+          return null; // Use default
+        }),
+        trackColor: WidgetStateProperty.resolveWith<Color?>((states) {
+          if (states.contains(WidgetState.selected)) {
+            return darkColorScheme.primary.withOpacity(0.5);
+          }
+          return null; // Use default
+        }),
+        trackOutlineColor: WidgetStateProperty.resolveWith<Color?>((states) {
+          if (states.contains(WidgetState.selected)) {
+            return Colors.transparent; // Optional: remove outline when selected
+          }
+          return null; // Use default outline color otherwise
+        }),
+      ),
+      snackBarTheme: SnackBarThemeData(
+        // Default style (errors will override background color)
+        backgroundColor: darkColorScheme.inverseSurface,
+        contentTextStyle: TextStyle(color: darkColorScheme.onInverseSurface),
+        actionTextColor: darkColorScheme.inversePrimary,
+      ),
+      dialogTheme: DialogTheme(
+        backgroundColor: darkColorScheme.surface,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        titleTextStyle: TextStyle(
+          color: darkColorScheme.onSurface,
+          fontSize: 20,
+          fontWeight: FontWeight.bold,
+        ),
+        contentTextStyle: TextStyle(
+          color: darkColorScheme.onSurfaceVariant,
+          fontSize: 16,
+        ),
+      ),
+      progressIndicatorTheme: ProgressIndicatorThemeData(
+        color: darkColorScheme.primary,
+      ),
+      textTheme: GoogleFonts.latoTextTheme(baseTheme.textTheme).copyWith(
+        // Customize specific text styles if needed
+        bodyMedium: GoogleFonts.lato(color: darkColorScheme.onSurface),
+        titleMedium: GoogleFonts.lato(color: darkColorScheme.onSurface),
+        labelLarge: GoogleFonts.lato(
+          fontWeight: FontWeight.bold,
+        ), // Often used in buttons
+      ),
+      // Add other component themes as needed
+    );
+  }
 }

--- a/lib/ui/views/auth/login_view.dart
+++ b/lib/ui/views/auth/login_view.dart
@@ -1,4 +1,5 @@
 import 'package:eventura/core/viewmodels/auth/login_viewmodel.dart';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -23,6 +24,7 @@ class LoginView extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
+                    Image.asset('assets/icon/icon.png', height: 100),
                     const SizedBox(height: 20),
                     TextField(
                       controller: _emailController,
@@ -84,10 +86,7 @@ class LoginView extends StatelessWidget {
                         child:
                             viewModel.isBusy
                                 ? const CircularProgressIndicator()
-                                : const Text(
-                                  'Sign In',
-                                  style: TextStyle(fontWeight: FontWeight.bold),
-                                ),
+                                : const Text('Sign In'),
                       ),
                     ),
                     if (viewModel.hasError &&
@@ -101,10 +100,6 @@ class LoginView extends StatelessWidget {
                         padding: const EdgeInsets.only(top: 20.0),
                         child: Text(
                           viewModel.errorMessage ?? "An unknown error occurred",
-                          style: const TextStyle(
-                            color: Colors.red,
-                            fontSize: 14,
-                          ),
                         ),
                       ),
                     const SizedBox(height: 40),
@@ -115,9 +110,10 @@ class LoginView extends StatelessWidget {
                           children: [
                             TextSpan(
                               text: "Sign Up",
-                              style: const TextStyle(
+                              style: TextStyle(
                                 fontWeight: FontWeight.bold,
-                                color: Colors.deepPurple,
+                                color: Theme.of(context).colorScheme.primary,
+                                decoration: TextDecoration.underline,
                               ),
                               recognizer:
                                   TapGestureRecognizer()

--- a/lib/ui/views/auth/reset_password_view.dart
+++ b/lib/ui/views/auth/reset_password_view.dart
@@ -1,4 +1,5 @@
 import 'package:eventura/core/viewmodels/auth/reset_password_viewmodel.dart';
+import 'package:eventura/ui/shared/app_colors.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -14,62 +15,70 @@ class ResetPasswordViewState extends State<ResetPasswordView> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text("Password Reset"), centerTitle: true),
-      body: Consumer<ResetPasswordViewmodel>(
-        builder: (context, vmodel, _) {
-          return Padding(
-            padding: const EdgeInsets.all(32.0),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  "Enter your email to reset your password.",
-                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.center,
-                ),
-                SizedBox(height: 30),
-                TextField(
-                  controller: _emailController,
-                  keyboardType: TextInputType.emailAddress,
-                  textCapitalization: TextCapitalization.none,
-                  autocorrect: false,
-                  decoration: InputDecoration(
-                    labelText: "Email",
-                    prefixIcon: const Icon(Icons.email),
-                    errorText: vmodel.hasError ? '' : null,
-                  ),
-                ),
-                SizedBox(height: 20),
-                if (vmodel.hasError)
+    return GestureDetector(
+      onTap: () {
+        FocusManager.instance.primaryFocus?.unfocus();
+      },
+      child: Scaffold(
+        appBar: AppBar(title: Text("Password Reset"), centerTitle: true),
+        body: Consumer<ResetPasswordViewmodel>(
+          builder: (context, vmodel, _) {
+            return Padding(
+              padding: const EdgeInsets.all(32.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
                   Text(
-                    vmodel.errorMessage!,
-                    style: TextStyle(color: Colors.red),
+                    "Enter your email to reset your password.",
+                    style: Theme.of(context).textTheme.titleMedium,
+                    textAlign: TextAlign.center,
                   ),
-                SizedBox(height: 35),
-                vmodel.isBusy
-                    ? CircularProgressIndicator()
-                    : ElevatedButton(
-                      onPressed: () async {
-                        final email = _emailController.text.trim();
-                        if (email.isNotEmpty) {
-                          await vmodel.resetPassword(email);
-                          if (!vmodel.hasError) {
-                            if (context.mounted) {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(content: Text("Reset email sent!")),
-                              );
-                              Navigator.pushReplacementNamed(context, '/login');
+                  SizedBox(height: 30),
+                  TextField(
+                    controller: _emailController,
+                    keyboardType: TextInputType.emailAddress,
+                    textCapitalization: TextCapitalization.none,
+                    autocorrect: false,
+                    decoration: InputDecoration(
+                      labelText: "Email",
+                      prefixIcon: const Icon(Icons.email),
+                      errorText: vmodel.hasError ? '' : null,
+                    ),
+                  ),
+                  SizedBox(height: 20),
+                  if (vmodel.hasError)
+                    Text(
+                      vmodel.errorMessage!,
+                      style: TextStyle(color: AppColors.errorRed),
+                    ),
+                  SizedBox(height: 35),
+                  vmodel.isBusy
+                      ? CircularProgressIndicator()
+                      : ElevatedButton(
+                        onPressed: () async {
+                          final email = _emailController.text.trim();
+                          if (email.isNotEmpty) {
+                            await vmodel.resetPassword(email);
+                            if (!vmodel.hasError) {
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(content: Text("Reset email sent!")),
+                                );
+                                Navigator.pushReplacementNamed(
+                                  context,
+                                  '/login',
+                                );
+                              }
                             }
                           }
-                        }
-                      },
-                      child: Text("Send"),
-                    ),
-              ],
-            ),
-          );
-        },
+                        },
+                        child: Text("Send"),
+                      ),
+                ],
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/ui/views/auth/signup_view.dart
+++ b/lib/ui/views/auth/signup_view.dart
@@ -1,4 +1,5 @@
 import 'package:eventura/core/viewmodels/auth/signup_viewmodel.dart';
+import 'package:eventura/ui/shared/app_colors.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -25,6 +26,7 @@ class SignupView extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
+                    Image.asset('assets/icon/icon.png', height: 100),
                     const SizedBox(height: 20),
                     TextField(
                       controller: _emailController,
@@ -85,8 +87,8 @@ class SignupView extends StatelessWidget {
                         onPressed:
                             viewModel.isBusy
                                 ? null
-                                : () {
-                                  viewModel.signUp(
+                                : () async {
+                                  await viewModel.signUp(
                                     context,
                                     email: _emailController.text.trim(),
                                     password: _passwordController.text,
@@ -98,16 +100,14 @@ class SignupView extends StatelessWidget {
                                     _passwordController.clear();
                                     _firstNameController.clear();
                                     _lastNameController.clear();
+                                    // ignore: use_build_context_synchronously
                                     _showConfirmationDialog(context);
                                   }
                                 },
                         child:
                             viewModel.isBusy
                                 ? const CircularProgressIndicator()
-                                : const Text(
-                                  'Sign Up',
-                                  style: TextStyle(fontWeight: FontWeight.bold),
-                                ),
+                                : const Text('Sign Up'),
                       ),
                     ),
                     if (viewModel.hasError &&
@@ -118,7 +118,7 @@ class SignupView extends StatelessWidget {
                         padding: const EdgeInsets.only(top: 20.0),
                         child: Text(
                           'Error: ${viewModel.errorMessage}',
-                          style: const TextStyle(color: Colors.red),
+                          style: const TextStyle(color: AppColors.errorRed),
                         ),
                       ),
                     const SizedBox(height: 30),
@@ -129,9 +129,10 @@ class SignupView extends StatelessWidget {
                           children: [
                             TextSpan(
                               text: "Sign In",
-                              style: const TextStyle(
+                              style: TextStyle(
                                 fontWeight: FontWeight.bold,
-                                color: Colors.deepPurple,
+                                color: Theme.of(context).colorScheme.primary,
+                                decoration: TextDecoration.underline,
                               ),
                               recognizer:
                                   TapGestureRecognizer()
@@ -156,23 +157,7 @@ class SignupView extends StatelessWidget {
   }
 
   void _showConfirmationDialog(BuildContext context) {
-    final dialog =
-    // code à décommenter en cas d'exécution sur appareil mobile
-    /* Platform.isIOS
-            ? CupertinoAlertDialog(
-              title: const Text("Email confirmation"),
-              content: const Text(
-                "Please confirm your email using the link we've sent you. You're going to be redirected to the sign in page.",
-              ),
-              actions: [
-                CupertinoDialogAction(
-                  child: const Text("OK"),
-                  onPressed:
-                      () => Navigator.pushReplacementNamed(context, "/login"),
-                ),
-              ],
-            ):*/
-    AlertDialog(
+    final dialog = AlertDialog(
       title: const Text("Email confirmation"),
       content: const Text(
         "Please confirm your email using the link we've sent you. You're going to be redirected to the sign in page.",

--- a/lib/ui/views/create_event_view.dart
+++ b/lib/ui/views/create_event_view.dart
@@ -29,29 +29,32 @@ class _CreateEventViewState extends State<CreateEventView> {
         appBar: AppBar(title: const Text("Create an event")),
         body: Consumer<EventViewmodel>(
           builder: (context, vmodel, child) {
-            return Padding(
-              padding: const EdgeInsets.all(32.0),
-              child: SingleChildScrollView(
-                child: Form(
-                  key: _formKey,
+            return SingleChildScrollView(
+              child: Form(
+                key: _formKey,
+                child: Padding(
+                  padding: const EdgeInsets.all(32.0),
                   child: Column(
                     children: [
                       TextFormField(
                         decoration: const InputDecoration(labelText: "Title"),
                         onChanged: (value) => title = value,
                       ),
+                      SizedBox(height: 8.0),
                       TextFormField(
                         decoration: const InputDecoration(
                           labelText: "Description",
                         ),
                         onChanged: (value) => description = value,
                       ),
+                      SizedBox(height: 8.0),
                       TextFormField(
                         decoration: const InputDecoration(
                           labelText: "Location",
                         ),
                         onChanged: (value) => location = value,
                       ),
+                      SizedBox(height: 8.0),
                       TextFormField(
                         decoration: const InputDecoration(
                           labelText: "Capacity",
@@ -59,21 +62,14 @@ class _CreateEventViewState extends State<CreateEventView> {
                         keyboardType: TextInputType.number,
                         onChanged: (value) => capacity = int.parse(value),
                       ),
+                      SizedBox(height: 8.0),
                       SwitchListTile(
                         title: const Text("Private Event"),
                         value: isPrivate,
                         onChanged: (value) => setState(() => isPrivate = value),
                       ),
-                      Container(height: 16),
+                      SizedBox(height: 16),
                       ElevatedButton(
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.purple,
-                          foregroundColor: Colors.white,
-                          padding: const EdgeInsets.symmetric(
-                            vertical: 18,
-                            horizontal: 27,
-                          ),
-                        ),
                         onPressed: () async {
                           if (_formKey.currentState!.validate()) {
                             final event = Event(
@@ -121,10 +117,7 @@ class _CreateEventViewState extends State<CreateEventView> {
                         child:
                             vmodel.isBusy
                                 ? CircularProgressIndicator()
-                                : Text(
-                                  "Create",
-                                  style: TextStyle(fontWeight: FontWeight.bold),
-                                ),
+                                : Text("Create"),
                       ),
                       SizedBox(height: 40),
                     ],

--- a/lib/ui/views/event_detail_view.dart
+++ b/lib/ui/views/event_detail_view.dart
@@ -1,4 +1,7 @@
 import 'package:eventura/core/viewmodels/event_viewmodel.dart';
+import 'package:eventura/ui/shared/app_colors.dart';
+
+import 'package:eventura/ui/widgets/destructive_button.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -25,7 +28,7 @@ class EventDetailView extends StatelessWidget {
               child: Center(
                 child: Text(
                   "An error occurred: ${vmodel.errorMessage}",
-                  style: TextStyle(color: Colors.red, fontSize: 20),
+                  style: TextStyle(color: AppColors.errorRed, fontSize: 20),
                   textAlign: TextAlign.center,
                 ),
               ),
@@ -42,10 +45,7 @@ class EventDetailView extends StatelessWidget {
               children: [
                 Text(
                   event.title,
-                  style: const TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: Theme.of(context).textTheme.titleLarge,
                 ),
                 const SizedBox(height: 30),
                 RichText(
@@ -53,13 +53,16 @@ class EventDetailView extends StatelessWidget {
                     children: <TextSpan>[
                       TextSpan(
                         text: "Location",
-                        style: TextStyle(
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                           decoration: TextDecoration.underline,
                           decorationThickness: 2,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
-                      TextSpan(text: " : ${event.title}"),
+                      TextSpan(
+                        text: " : ${event.title}",
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
                     ],
                   ),
                 ),
@@ -69,13 +72,16 @@ class EventDetailView extends StatelessWidget {
                     children: <TextSpan>[
                       TextSpan(
                         text: "Description",
-                        style: TextStyle(
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                           decoration: TextDecoration.underline,
                           decorationThickness: 2,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
-                      TextSpan(text: " : ${event.description}"),
+                      TextSpan(
+                        text: " : ${event.description}",
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
                     ],
                   ),
                 ),
@@ -84,7 +90,8 @@ class EventDetailView extends StatelessWidget {
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                   children: [
-                    ElevatedButton(
+                    DestructiveButton(
+                      icon: Icons.delete,
                       onPressed: () {
                         showDialog(
                           context: context,
@@ -95,59 +102,47 @@ class EventDetailView extends StatelessWidget {
                                   "Are you sure you want to delete this event?",
                                 ),
                                 actions: [
-                                  TextButton(
+                                  ElevatedButton(
                                     onPressed: () => Navigator.pop(context),
                                     child: const Text("Cancel"),
                                   ),
-                                  ElevatedButton(
-                                    onPressed: () async {
-                                      await vmodel.deleteEvent(
-                                        context,
-                                        vmodel.event!.eventId!,
-                                      );
-                                      if (context.mounted) {
-                                        ScaffoldMessenger.of(
+                                  Padding(
+                                    padding: const EdgeInsets.all(12.0),
+                                    child: DestructiveButton(
+                                      icon: Icons.delete,
+                                      onPressed: () async {
+                                        await vmodel.deleteEvent(
                                           context,
-                                        ).showSnackBar(
-                                          SnackBar(
-                                            content:
-                                                vmodel.hasError
-                                                    ? Text(vmodel.errorMessage!)
-                                                    : Text(
-                                                      "Event deleted successfully",
-                                                    ),
-                                          ),
+                                          vmodel.event!.eventId!,
                                         );
-                                        Navigator.pop(context);
-                                      }
-                                    },
-                                    style: ElevatedButton.styleFrom(
-                                      backgroundColor: Colors.red,
-                                    ),
-                                    child:
-                                        vmodel.isBusy
-                                            ? CircularProgressIndicator()
-                                            : Text(
-                                              "Delete",
-                                              style: TextStyle(
-                                                color: Colors.white,
-                                              ),
+                                        if (context.mounted) {
+                                          ScaffoldMessenger.of(
+                                            context,
+                                          ).showSnackBar(
+                                            SnackBar(
+                                              content:
+                                                  vmodel.hasError
+                                                      ? Text(
+                                                        vmodel.errorMessage!,
+                                                      )
+                                                      : Text(
+                                                        "Event deleted successfully",
+                                                      ),
                                             ),
+                                          );
+                                          Navigator.pop(context);
+                                        }
+                                      },
+                                      label: "Delete",
+                                      isLoading: vmodel.isBusy,
+                                    ),
                                   ),
                                 ],
                               ),
                         );
                       },
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.red,
-                      ),
-                      child: const Text(
-                        "Delete",
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
+                      label: "Delete",
+                      isLoading: vmodel.isBusy,
                     ),
                   ],
                 ),

--- a/lib/ui/views/event_detail_view.dart
+++ b/lib/ui/views/event_detail_view.dart
@@ -56,15 +56,10 @@ class EventDetailView extends StatelessWidget {
                         style: TextStyle(
                           decoration: TextDecoration.underline,
                           decorationThickness: 2,
-                          decorationColor: Colors.black,
                           fontWeight: FontWeight.bold,
-                          color: Colors.black,
                         ),
                       ),
-                      TextSpan(
-                        text: " : ${event.title}",
-                        style: TextStyle(color: Colors.black),
-                      ),
+                      TextSpan(text: " : ${event.title}"),
                     ],
                   ),
                 ),
@@ -77,15 +72,10 @@ class EventDetailView extends StatelessWidget {
                         style: TextStyle(
                           decoration: TextDecoration.underline,
                           decorationThickness: 2,
-                          decorationColor: Colors.black,
                           fontWeight: FontWeight.bold,
-                          color: Colors.black,
                         ),
                       ),
-                      TextSpan(
-                        text: " : ${event.description}",
-                        style: TextStyle(color: Colors.black),
-                      ),
+                      TextSpan(text: " : ${event.description}"),
                     ],
                   ),
                 ),

--- a/lib/ui/views/events_list_view.dart
+++ b/lib/ui/views/events_list_view.dart
@@ -1,6 +1,5 @@
-// events_list_view.dart
-// import 'package:eventura/core/services/auth_service.dart';
 import 'package:eventura/core/viewmodels/events_list_viewmodel.dart';
+import 'package:eventura/ui/shared/app_colors.dart';
 import 'package:eventura/ui/widgets/event_card.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -19,15 +18,42 @@ class EventListViewState extends State<EventListView> {
       builder: (context, vmodel, child) {
         if (vmodel.hasError) {
           return Center(
-            child: Text(
-              "Error: ${vmodel.errorMessage!}",
-              style: TextStyle(color: Colors.red),
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.error_outline,
+                    color: AppColors.errorRed,
+                    size: 48,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    "Error: ${vmodel.errorMessage!}",
+                    style: TextStyle(
+                      color: AppColors.errorRed,
+                      fontWeight: FontWeight.w500,
+                      fontSize: 16,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => vmodel.refreshEvents(),
+                    child: const Text("Try Again"),
+                  ),
+                ],
+              ),
             ),
           );
         }
         if (vmodel.events.isEmpty) {
           return Center(
-            child: Text("No events found", style: TextStyle(fontSize: 17)),
+            child: Text(
+              "No events found",
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
           );
         }
         return RefreshIndicator(

--- a/lib/ui/views/friends_view.dart
+++ b/lib/ui/views/friends_view.dart
@@ -24,10 +24,7 @@ class _FriendsViewState extends State<FriendsView> {
       backgroundColor: Colors.purple,
       foregroundColor: Colors.white,
     );
-    final unselected = ElevatedButton.styleFrom(
-      backgroundColor: null,
-      foregroundColor: Colors.black,
-    );
+    final unselected = ElevatedButton.styleFrom(backgroundColor: null);
     switch (pageSwitch) {
       case Page.friends:
         if (pageIndex == 0) {

--- a/lib/ui/views/friends_view.dart
+++ b/lib/ui/views/friends_view.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:eventura/core/models/user.dart';
 import 'package:eventura/core/services/auth_service.dart';
 import 'package:eventura/core/viewmodels/friends_viewmodel.dart';

--- a/lib/ui/views/friends_view.dart
+++ b/lib/ui/views/friends_view.dart
@@ -1,6 +1,9 @@
+import 'dart:ui';
+
 import 'package:eventura/core/models/user.dart';
 import 'package:eventura/core/services/auth_service.dart';
 import 'package:eventura/core/viewmodels/friends_viewmodel.dart';
+import 'package:eventura/ui/shared/app_colors.dart';
 import 'package:eventura/ui/views/profile_view.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -24,7 +27,10 @@ class _FriendsViewState extends State<FriendsView> {
       backgroundColor: Colors.purple,
       foregroundColor: Colors.white,
     );
-    final unselected = ElevatedButton.styleFrom(backgroundColor: null);
+    final unselected = ElevatedButton.styleFrom(
+      backgroundColor: AppColors.secondaryGrey,
+      foregroundColor: AppColors.onSecondaryGrey,
+    );
     switch (pageSwitch) {
       case Page.friends:
         if (pageIndex == 0) {
@@ -108,10 +114,11 @@ class _FriendsViewState extends State<FriendsView> {
                         children: [
                           Text(
                             "Add a friend",
-                            style: TextStyle(
-                              color: Colors.black,
-                              fontSize: 20,
+                            style: Theme.of(
+                              context,
+                            ).textTheme.titleMedium?.copyWith(
                               fontWeight: FontWeight.bold,
+                              fontSize: 20,
                             ),
                           ),
                           SizedBox(height: 8),
@@ -125,6 +132,9 @@ class _FriendsViewState extends State<FriendsView> {
                             viewConstraints: const BoxConstraints(
                               maxHeight: 300,
                             ),
+                            viewBackgroundColor:
+                                Theme.of(context).scaffoldBackgroundColor,
+                            viewElevation: 4.0,
                             suggestionsBuilder: (
                               BuildContext context,
                               SearchController controller,
@@ -185,56 +195,101 @@ class _FriendsViewState extends State<FriendsView> {
                                   ];
                                 }
 
-                                return searchResults.map(
-                                  (user) => ListTile(
-                                    title: Text(
-                                      '${user.firstName} ${user.lastName}',
-                                    ),
-                                    subtitle: Text(user.email),
-                                    onTap: () {
-                                      controller.closeView(user.email);
-                                      showDialog(
-                                        context: context,
-                                        builder:
-                                            (context) => AlertDialog(
-                                              title: Text(
-                                                'Do you really want to add ${user.firstName} ${user.lastName} as a friend?',
+                                return searchResults
+                                    .map(
+                                      (user) => Padding(
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: 8.0,
+                                        ),
+                                        child: ListTile(
+                                          contentPadding:
+                                              const EdgeInsets.symmetric(
+                                                horizontal: 16.0,
+                                                vertical: 8.0,
                                               ),
-                                              actions: [
-                                                TextButton(
-                                                  onPressed: () {
-                                                    _viewModel
-                                                        .sendFriendRequest(
-                                                          _currentUser.userId,
-                                                          user.userId,
-                                                        );
-                                                    ScaffoldMessenger.of(
-                                                      context,
-                                                    ).showSnackBar(
-                                                      SnackBar(
-                                                        content: Text(
-                                                          'Friend request sent!',
-                                                        ),
+                                          title: Text(
+                                            '${user.firstName} ${user.lastName}',
+                                            style:
+                                                Theme.of(
+                                                  context,
+                                                ).textTheme.titleMedium,
+                                          ),
+                                          subtitle: Text(user.email),
+                                          onTap: () {
+                                            controller.closeView(user.email);
+                                            showDialog(
+                                              context: context,
+                                              builder:
+                                                  (context) => AlertDialog(
+                                                    title: Text(
+                                                      'Do you really want to add ${user.firstName} ${user.lastName} as a friend?',
+                                                    ),
+                                                    actions: [
+                                                      TextButton(
+                                                        onPressed: () async {
+                                                          await _viewModel
+                                                              .sendFriendRequest(
+                                                                _currentUser
+                                                                    .userId,
+                                                                user.userId,
+                                                              );
+                                                          if (!_viewModel
+                                                              .hasError) {
+                                                            ScaffoldMessenger.of(
+                                                              context,
+                                                            ).showSnackBar(
+                                                              SnackBar(
+                                                                content: Text(
+                                                                  'Friend request sent!',
+                                                                ),
+                                                              ),
+                                                            );
+                                                            _loadData();
+                                                            Navigator.pop(
+                                                              context,
+                                                            );
+                                                            Navigator.pop(
+                                                              context,
+                                                            );
+                                                          } else {
+                                                            ScaffoldMessenger.of(
+                                                              context,
+                                                            ).showSnackBar(
+                                                              SnackBar(
+                                                                content: Text(
+                                                                  'An error occurred while sending the friend request: ${_viewModel.errorMessage}',
+                                                                ),
+                                                              ),
+                                                            );
+                                                            _viewModel.setError(
+                                                              null,
+                                                            );
+                                                            Navigator.pop(
+                                                              context,
+                                                            );
+                                                            Navigator.pop(
+                                                              context,
+                                                            );
+                                                          }
+                                                        },
+                                                        child: Text('Yes'),
                                                       ),
-                                                    );
-                                                    _loadData();
-                                                    Navigator.pop(context);
-                                                    Navigator.pop(context);
-                                                  },
-                                                  child: Text('Yes'),
-                                                ),
-                                                TextButton(
-                                                  onPressed: () {
-                                                    Navigator.pop(context);
-                                                  },
-                                                  child: Text('No'),
-                                                ),
-                                              ],
-                                            ),
-                                      );
-                                    },
-                                  ),
-                                );
+                                                      TextButton(
+                                                        onPressed: () {
+                                                          Navigator.pop(
+                                                            context,
+                                                          );
+                                                        },
+                                                        child: Text('No'),
+                                                      ),
+                                                    ],
+                                                  ),
+                                            );
+                                          },
+                                        ),
+                                      ),
+                                    )
+                                    .toList();
                               } catch (e) {
                                 if (e.toString().contains(
                                   "Search failed: no data returned",
@@ -280,39 +335,33 @@ class _FriendsViewState extends State<FriendsView> {
                 SizedBox(height: 8),
                 SingleChildScrollView(
                   scrollDirection: Axis.horizontal,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      ElevatedButton(
-                        style: _buttonStyle(_pageSelect, 0),
-                        onPressed:
-                            () => setState(() => _pageSelect = Page.friends),
-                        child: Text(
-                          'My Friends',
-                          style: TextStyle(fontWeight: FontWeight.bold),
+                  child: Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: [
+                        ElevatedButton(
+                          style: _buttonStyle(_pageSelect, 0),
+                          onPressed:
+                              () => setState(() => _pageSelect = Page.friends),
+                          child: Text('My Friends'),
                         ),
-                      ),
-                      SizedBox(width: 8),
-                      ElevatedButton(
-                        style: _buttonStyle(_pageSelect, 1),
-                        onPressed:
-                            () => setState(() => _pageSelect = Page.received),
-                        child: Text(
-                          'Received Requests',
-                          style: TextStyle(fontWeight: FontWeight.bold),
+                        SizedBox(width: 8),
+                        ElevatedButton(
+                          style: _buttonStyle(_pageSelect, 1),
+                          onPressed:
+                              () => setState(() => _pageSelect = Page.received),
+                          child: Text('Received Requests'),
                         ),
-                      ),
-                      SizedBox(width: 8),
-                      ElevatedButton(
-                        style: _buttonStyle(_pageSelect, 2),
-                        onPressed:
-                            () => setState(() => _pageSelect = Page.sent),
-                        child: Text(
-                          'Sent Requests',
-                          style: TextStyle(fontWeight: FontWeight.bold),
+                        SizedBox(width: 8),
+                        ElevatedButton(
+                          style: _buttonStyle(_pageSelect, 2),
+                          onPressed:
+                              () => setState(() => _pageSelect = Page.sent),
+                          child: Text('Sent Requests'),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
                 SizedBox(height: 15),
@@ -323,12 +372,14 @@ class _FriendsViewState extends State<FriendsView> {
                           : _pageSelect == Page.received
                           ? ListView(
                             children: [
-                              const ListTile(
+                              ListTile(
                                 title: Text(
                                   'Pending Requests',
-                                  style: TextStyle(
-                                    fontWeight: FontWeight.bold,
+                                  style: Theme.of(
+                                    context,
+                                  ).textTheme.labelMedium?.copyWith(
                                     fontSize: 18,
+                                    fontWeight: FontWeight.bold,
                                   ),
                                 ),
                               ),
@@ -353,26 +404,22 @@ class _FriendsViewState extends State<FriendsView> {
                                   },
                                   leading: Icon(Icons.person, size: 32),
 
-                                  title: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        '${entry.value!.firstName} ${entry.value!.lastName}',
-                                        style: TextStyle(
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
-                                      Text(
-                                        entry.value!.email,
-                                        style: TextStyle(
-                                          color: Colors.grey,
-                                          fontStyle: FontStyle.italic,
-                                        ),
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
-                                    ],
+                                  title: Text(
+                                    '${entry.value!.firstName} ${entry.value!.lastName}',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .titleMedium
+                                        ?.copyWith(fontWeight: FontWeight.bold),
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                  subtitle: Text(
+                                    entry.value!.email,
+                                    style: TextStyle(
+                                      color: AppColors.onSecondaryGreyVariant,
+                                      fontStyle: FontStyle.italic,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                    overflow: TextOverflow.ellipsis,
                                   ),
                                   trailing: Row(
                                     mainAxisSize: MainAxisSize.min,
@@ -428,12 +475,14 @@ class _FriendsViewState extends State<FriendsView> {
                           : _pageSelect == Page.friends
                           ? ListView(
                             children: [
-                              const ListTile(
+                              ListTile(
                                 title: Text(
                                   'Friends',
-                                  style: TextStyle(
-                                    fontWeight: FontWeight.bold,
+                                  style: Theme.of(
+                                    context,
+                                  ).textTheme.labelMedium?.copyWith(
                                     fontSize: 18,
+                                    fontWeight: FontWeight.bold,
                                   ),
                                 ),
                               ),
@@ -466,41 +515,40 @@ class _FriendsViewState extends State<FriendsView> {
                                                   child:
                                                       vmodel.isBusy
                                                           ? CircularProgressIndicator()
-                                                          : Text('Yes'),
+                                                          : Text(
+                                                            'Yes',
+                                                            style: TextStyle(
+                                                              color:
+                                                                  AppColors
+                                                                      .errorRed,
+                                                            ),
+                                                          ),
                                                   onPressed: () async {
                                                     await vmodel.deleteFriend(
                                                       friendship,
                                                     );
-                                                    if (context.mounted) {
-                                                      Navigator.pop(context);
-                                                    }
+                                                    Navigator.pop(context);
 
                                                     if (_viewModel.hasError) {
-                                                      if (context.mounted) {
-                                                        ScaffoldMessenger.of(
-                                                          context,
-                                                        ).showSnackBar(
-                                                          SnackBar(
-                                                            backgroundColor:
-                                                                Colors.red,
-                                                            content: Text(
-                                                              "Error: ${_viewModel.errorMessage!}",
-                                                            ),
+                                                      ScaffoldMessenger.of(
+                                                        context,
+                                                      ).showSnackBar(
+                                                        SnackBar(
+                                                          content: Text(
+                                                            "Error: ${_viewModel.errorMessage!}",
                                                           ),
-                                                        );
-                                                      } else {
-                                                        if (context.mounted) {
-                                                          ScaffoldMessenger.of(
-                                                            context,
-                                                          ).showSnackBar(
-                                                            SnackBar(
-                                                              content: Text(
-                                                                'Friend deleted: ${vmodel.friends[friendship]!.firstName} ${vmodel.friends[friendship]!.lastName}',
-                                                              ),
-                                                            ),
-                                                          );
-                                                        }
-                                                      }
+                                                        ),
+                                                      );
+                                                    } else {
+                                                      ScaffoldMessenger.of(
+                                                        context,
+                                                      ).showSnackBar(
+                                                        SnackBar(
+                                                          content: Text(
+                                                            'Friend deleted: ${vmodel.friends[friendship]!.firstName} ${vmodel.friends[friendship]!.lastName}',
+                                                          ),
+                                                        ),
+                                                      );
                                                     }
                                                     _loadData();
                                                   },
@@ -514,38 +562,31 @@ class _FriendsViewState extends State<FriendsView> {
                                               ],
                                               content: Text(
                                                 'Are you sure you want to delete this friend?',
-                                                style: TextStyle(
-                                                  fontSize: 16,
-                                                  color: Colors.black,
-                                                  fontWeight: FontWeight.bold,
-                                                ),
+                                                style:
+                                                    Theme.of(
+                                                      context,
+                                                    ).textTheme.titleMedium,
                                               ),
                                             ),
                                       );
                                     },
                                   ),
                                   title: Text(
-                                    style: TextStyle(
-                                      fontWeight: FontWeight.bold,
-                                    ),
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .titleMedium
+                                        ?.copyWith(fontWeight: FontWeight.bold),
+                                    overflow: TextOverflow.ellipsis,
                                     '${vmodel.friends[friendship]?.firstName} ${vmodel.friends[friendship]?.lastName}',
                                   ),
-                                  subtitle: RichText(
-                                    text: TextSpan(
-                                      children: <TextSpan>[
-                                        TextSpan(
-                                          text: 'since ',
-                                          style: TextStyle(
-                                            color: Colors.blueGrey,
-                                            fontSize: 15,
-                                          ),
-                                        ),
-                                        TextSpan(
-                                          text: friendship.createdAt,
-                                          style: TextStyle(color: Colors.black),
-                                        ),
-                                      ],
+                                  subtitle: Text(
+                                    vmodel.friends[friendship]!.email,
+                                    style: TextStyle(
+                                      color: AppColors.onSecondaryGreyVariant,
+                                      fontStyle: FontStyle.italic,
+                                      fontWeight: FontWeight.bold,
                                     ),
+                                    overflow: TextOverflow.ellipsis,
                                   ),
                                 ),
                               SizedBox(height: 10),
@@ -553,12 +594,14 @@ class _FriendsViewState extends State<FriendsView> {
                           )
                           : ListView(
                             children: [
-                              const ListTile(
+                              ListTile(
                                 title: Text(
                                   'Sent Requests',
-                                  style: TextStyle(
-                                    fontWeight: FontWeight.bold,
+                                  style: Theme.of(
+                                    context,
+                                  ).textTheme.labelMedium?.copyWith(
                                     fontSize: 18,
+                                    fontWeight: FontWeight.bold,
                                   ),
                                 ),
                               ),
@@ -583,26 +626,22 @@ class _FriendsViewState extends State<FriendsView> {
                                   },
                                   leading: Icon(Icons.person, size: 32),
 
-                                  title: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        '${entry.value!.firstName} ${entry.value!.lastName}',
-                                        style: TextStyle(
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
-                                      Text(
-                                        entry.value!.email,
-                                        style: TextStyle(
-                                          color: Colors.grey,
-                                          fontStyle: FontStyle.italic,
-                                        ),
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
-                                    ],
+                                  title: Text(
+                                    '${entry.value!.firstName} ${entry.value!.lastName}',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .titleMedium
+                                        ?.copyWith(fontWeight: FontWeight.bold),
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                  subtitle: Text(
+                                    entry.value!.email,
+                                    style: TextStyle(
+                                      color: AppColors.onSecondaryGreyVariant,
+                                      fontStyle: FontStyle.italic,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                    overflow: TextOverflow.ellipsis,
                                   ),
                                   trailing: IconButton(
                                     iconSize: 25,
@@ -617,7 +656,6 @@ class _FriendsViewState extends State<FriendsView> {
                                             context,
                                           ).showSnackBar(
                                             SnackBar(
-                                              backgroundColor: Colors.red,
                                               content: Text(
                                                 "Error cancelling friend request: ${_viewModel.errorMessage}",
                                               ),

--- a/lib/ui/views/homepage_view.dart
+++ b/lib/ui/views/homepage_view.dart
@@ -1,5 +1,7 @@
 import 'package:eventura/core/services/auth_service.dart';
+
 import 'package:eventura/core/viewmodels/profile_viewmodel.dart';
+import 'package:eventura/ui/shared/app_colors.dart';
 import 'package:eventura/ui/shared/is_editing_profile.dart';
 import 'package:eventura/ui/views/events_list_view.dart';
 import 'package:eventura/ui/views/friends_view.dart';
@@ -34,8 +36,10 @@ class _HomepageViewState extends State<HomepageView> {
 
   final _pressedStyle =
       (int i, int currentPage) => ElevatedButton.styleFrom(
-        backgroundColor: currentPage == i ? Colors.purple : null,
-        foregroundColor: currentPage == i ? Colors.white : null,
+        backgroundColor:
+            currentPage == i ? Colors.purple : AppColors.secondaryGrey,
+        foregroundColor:
+            currentPage == i ? Colors.white : AppColors.onSecondaryGrey,
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
       );
 
@@ -43,6 +47,7 @@ class _HomepageViewState extends State<HomepageView> {
   Widget build(BuildContext context) {
     final authService = Provider.of<AuthService>(context);
     final currentUserId = authService.currentUser!.id;
+    final titleMedium = Theme.of(context).textTheme.titleMedium;
 
     final profileView = ProfileView(userId: currentUserId, fromHome: true);
     return ChangeNotifierProvider.value(
@@ -116,90 +121,52 @@ class _HomepageViewState extends State<HomepageView> {
                         children: [
                           SizedBox(
                             height: 125,
-                            child: const DrawerHeader(
+                            child: DrawerHeader(
                               child: Text(
                                 'Menu',
-                                style: TextStyle(
-                                  fontSize: 30,
-                                  fontWeight: FontWeight.bold,
-                                ),
+                                style: Theme.of(context).textTheme.titleLarge
+                                    ?.copyWith(fontWeight: FontWeight.bold),
                               ),
                             ),
                           ),
                           SizedBox(height: 16),
                           ListTile(
-                            title: const Text(
-                              'Home',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
+                            title: Text('Home', style: titleMedium),
                             onTap: () {
                               Navigator.pushNamed(context, '/home');
                             },
                           ),
                           const Divider(indent: 7, thickness: 2),
                           ListTile(
-                            title: const Text(
-                              'Profile',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
+                            title: Text('Profile', style: titleMedium),
                             onTap: () {
                               Navigator.pushNamed(context, '/profile');
                             },
                           ),
                           const Divider(indent: 7, thickness: 2),
                           ListTile(
-                            title: const Text(
-                              'Settings',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
+                            title: Text('Settings', style: titleMedium),
                             onTap: () {
                               Navigator.pushNamed(context, '/settings');
                             },
                           ),
                           const Divider(indent: 7, thickness: 2),
                           ListTile(
-                            title: const Text(
-                              'FAQ',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
+                            title: Text('FAQ', style: titleMedium),
                             onTap: () {
                               Navigator.pushNamed(context, '/faq');
                             },
                           ),
                           const Divider(indent: 7, thickness: 2),
                           ListTile(
-                            title: const Text(
-                              'About',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
+                            title: Text('About', style: titleMedium),
                             onTap: () {
                               Navigator.pushNamed(context, '/about');
                             },
                           ),
                           const Divider(indent: 7, thickness: 2),
                           ListTile(
-                            title: const Text(
-                              'Contact',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
+                            title: Text('Contact', style: titleMedium),
                             onTap: () {
                               Navigator.pushNamed(context, '/contact');
                             },
@@ -212,7 +179,10 @@ class _HomepageViewState extends State<HomepageView> {
                       child: Text(
                         "Version 1.0.0",
                         textAlign: TextAlign.center,
-                        style: TextStyle(fontSize: 16, color: Colors.grey),
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: AppColors.onSecondaryGrey,
+                        ),
                       ),
                     ),
                     SizedBox(height: 48.0),
@@ -248,12 +218,7 @@ class _HomepageViewState extends State<HomepageView> {
                                       onPressed: () {
                                         setState(() => _eventTypeIndex = 1);
                                       },
-                                      child: const Text(
-                                        'My Events',
-                                        style: TextStyle(
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                      ),
+                                      child: const Text('My Events'),
                                     ),
                                     SizedBox(width: 10),
                                     ElevatedButton(
@@ -261,12 +226,7 @@ class _HomepageViewState extends State<HomepageView> {
                                       onPressed: () {
                                         setState(() => _eventTypeIndex = 2);
                                       },
-                                      child: const Text(
-                                        'Events',
-                                        style: TextStyle(
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                      ),
+                                      child: const Text('Events'),
                                     ),
                                     SizedBox(width: 10),
                                     ElevatedButton(
@@ -274,12 +234,7 @@ class _HomepageViewState extends State<HomepageView> {
                                       onPressed: () {
                                         setState(() => _eventTypeIndex = 3);
                                       },
-                                      child: const Text(
-                                        'Invitations',
-                                        style: TextStyle(
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                      ),
+                                      child: const Text('Invitations'),
                                     ),
                                   ],
                                 ),

--- a/lib/ui/views/homepage_view.dart
+++ b/lib/ui/views/homepage_view.dart
@@ -35,7 +35,7 @@ class _HomepageViewState extends State<HomepageView> {
   final _pressedStyle =
       (int i, int currentPage) => ElevatedButton.styleFrom(
         backgroundColor: currentPage == i ? Colors.purple : null,
-        foregroundColor: currentPage == i ? Colors.white : Colors.black,
+        foregroundColor: currentPage == i ? Colors.white : null,
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
       );
 

--- a/lib/ui/views/messages_view.dart
+++ b/lib/ui/views/messages_view.dart
@@ -1,3 +1,4 @@
+import 'package:eventura/ui/static/coming_soon.dart';
 import 'package:flutter/material.dart';
 
 class MessagesView extends StatelessWidget {
@@ -5,8 +6,6 @@ class MessagesView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Text('Coming soon! ⏳', style: TextStyle(fontSize: 24)),
-    );
+    return ComingSoon(title: "Messages");
   }
 }

--- a/lib/ui/views/profile_view.dart
+++ b/lib/ui/views/profile_view.dart
@@ -3,10 +3,10 @@ import 'package:eventura/core/viewmodels/friends_viewmodel.dart';
 import 'package:eventura/core/viewmodels/profile_viewmodel.dart';
 import 'package:eventura/ui/shared/is_editing_profile.dart';
 import 'package:eventura/ui/views/auth/login_view.dart';
+import 'package:eventura/ui/widgets/destructive_button.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:logger/logger.dart';
-// import 'package:supabase_flutter/supabase_flutter.dart';
 
 class ProfileView extends StatefulWidget {
   final String userId;
@@ -157,10 +157,14 @@ class _ProfileViewState extends State<ProfileView> {
       return false;
     }
 
-    if (!_controllersInitialized) {
+    initializeControllers() {
       firstNameController.text = user.firstName ?? '';
       lastNameController.text = user.lastName ?? '';
       emailController.text = user.email;
+    }
+
+    if (!_controllersInitialized) {
+      initializeControllers();
       _controllersInitialized = true;
     }
 
@@ -267,6 +271,8 @@ class _ProfileViewState extends State<ProfileView> {
                                             ),
                                           ),
                                         );
+                                        editingState.toggleEditing();
+                                        return;
                                       } else {
                                         final updatedUser = user.copyWith(
                                           firstName: firstNameController.text,
@@ -275,32 +281,38 @@ class _ProfileViewState extends State<ProfileView> {
                                         );
 
                                         await viewmodel.updateUser(updatedUser);
-                                      }
-                                      if (!viewmodel.hasError) {
-                                        if (context.mounted) {
-                                          ScaffoldMessenger.of(
-                                            context,
-                                          ).showSnackBar(
-                                            const SnackBar(
-                                              content: Text("Profile updated"),
-                                            ),
-                                          );
-                                          _loadData();
-                                        }
-                                      } else {
-                                        if (context.mounted) {
-                                          ScaffoldMessenger.of(
-                                            context,
-                                          ).showSnackBar(
-                                            SnackBar(
-                                              content: Text(
-                                                "Error updating profile : ${viewmodel.errorMessage}",
+                                        if (!viewmodel.hasError) {
+                                          if (context.mounted) {
+                                            ScaffoldMessenger.of(
+                                              context,
+                                            ).showSnackBar(
+                                              const SnackBar(
+                                                content: Text(
+                                                  "Profile updated",
+                                                ),
                                               ),
-                                            ),
-                                          );
+                                            );
+                                            _loadData();
+                                            editingState.toggleEditing();
+                                            return;
+                                          }
+                                        } else {
+                                          if (context.mounted) {
+                                            ScaffoldMessenger.of(
+                                              context,
+                                            ).showSnackBar(
+                                              SnackBar(
+                                                content: Text(
+                                                  "Error updating profile : ${viewmodel.errorMessage}",
+                                                ),
+                                              ),
+                                            );
+                                            initializeControllers();
+                                            editingState.toggleEditing();
+                                            return;
+                                          }
                                         }
                                       }
-                                      editingState.toggleEditing();
                                     },
                                     child: const Text(
                                       'Save Changes',
@@ -375,44 +387,37 @@ class _ProfileViewState extends State<ProfileView> {
                           Column(
                             children: [
                               ElevatedButton(
-                                style: ElevatedButton.styleFrom(
-                                  // backgroundColor: Colors.grey,
-                                  // foregroundColor: Colors.white,
-                                  padding: EdgeInsets.symmetric(
-                                    horizontal: 20,
-                                    vertical: 13,
+                                style: Theme.of(
+                                  context,
+                                ).elevatedButtonTheme.style?.copyWith(
+                                  minimumSize: WidgetStateProperty.all(
+                                    const Size(200, 48),
                                   ),
                                 ),
                                 child:
                                     viewmodel.isBusy
-                                        ? CircularProgressIndicator()
-                                        : SizedBox(
-                                          width: 150,
-                                          child: Row(
-                                            mainAxisAlignment:
-                                                MainAxisAlignment.center,
-                                            children: [
-                                              Icon(
-                                                Icons.password,
-                                                color: Colors.white,
-                                              ),
-                                              SizedBox(width: 7),
-                                              Text(
-                                                "Reset Password",
-                                                style: TextStyle(
-                                                  fontSize: 15,
-                                                  fontWeight: FontWeight.bold,
-                                                ),
-                                              ),
-                                            ],
-                                          ),
+                                        ? const CircularProgressIndicator()
+                                        : Row(
+                                          mainAxisSize: MainAxisSize.min,
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.center,
+                                          children: [
+                                            Icon(
+                                              Icons.password,
+                                              color:
+                                                  Theme.of(
+                                                    context,
+                                                  ).colorScheme.onPrimary,
+                                            ),
+                                            const SizedBox(width: 8),
+                                            const Text("Reset Password"),
+                                          ],
                                         ),
                                 onPressed: () {
                                   viewmodel.resetPassword();
                                   if (viewmodel.hasError) {
                                     ScaffoldMessenger.of(context).showSnackBar(
                                       SnackBar(
-                                        backgroundColor: Colors.red,
                                         content: Text(
                                           "An error occurred: ${viewmodel.errorMessage}",
                                         ),
@@ -431,59 +436,54 @@ class _ProfileViewState extends State<ProfileView> {
                               ),
                               SizedBox(height: 16),
                               ElevatedButton(
-                                style: ElevatedButton.styleFrom(
-                                  // backgroundColor: Colors.grey,
-                                  // foregroundColor: Colors.white,
-                                  padding: EdgeInsets.symmetric(
-                                    horizontal: 20,
-                                    vertical: 13,
+                                style: Theme.of(
+                                  context,
+                                ).elevatedButtonTheme.style?.copyWith(
+                                  backgroundColor: WidgetStateProperty.all(
+                                    Theme.of(
+                                      context,
+                                    ).colorScheme.secondaryContainer,
+                                  ),
+                                  foregroundColor: WidgetStateProperty.all(
+                                    Theme.of(
+                                      context,
+                                    ).colorScheme.onSecondaryContainer,
+                                  ),
+                                  minimumSize: WidgetStateProperty.all(
+                                    const Size(200, 48),
                                   ),
                                 ),
                                 child:
                                     viewmodel.isBusy
-                                        ? CircularProgressIndicator(
-                                          color: Colors.white,
-                                        )
-                                        : SizedBox(
-                                          width: 100,
-                                          child: Row(
-                                            mainAxisAlignment:
-                                                MainAxisAlignment.center,
-                                            children: [
-                                              Icon(
-                                                Icons.logout,
-                                                color: Colors.white,
-                                              ),
-                                              SizedBox(width: 5),
-                                              Text(
-                                                "Sign Out",
-                                                style: TextStyle(
-                                                  fontSize: 15,
-                                                  fontWeight: FontWeight.bold,
-                                                ),
-                                              ),
-                                            ],
-                                          ),
+                                        ? CircularProgressIndicator()
+                                        : Row(
+                                          mainAxisSize: MainAxisSize.min,
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.center,
+                                          children: [
+                                            Icon(Icons.logout),
+                                            const SizedBox(width: 8),
+                                            const Text("Sign Out"),
+                                          ],
                                         ),
                                 onPressed: () {
                                   viewmodel.signOut();
-                                  Navigator.pushAndRemoveUntil(
-                                    context,
-                                    MaterialPageRoute(
-                                      builder: (context) => LoginView(),
-                                    ),
-                                    (Route<dynamic> route) => false,
-                                  );
                                   if (viewmodel.hasError) {
                                     ScaffoldMessenger.of(context).showSnackBar(
                                       SnackBar(
-                                        backgroundColor: Colors.red,
                                         content: Text(
                                           "An error occurred while signing out. Please try again later or contact support: ${viewmodel.errorMessage}",
                                         ),
                                       ),
                                     );
                                   } else {
+                                    Navigator.pushAndRemoveUntil(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder: (context) => LoginView(),
+                                      ),
+                                      (Route<dynamic> route) => false,
+                                    );
                                     ScaffoldMessenger.of(context).showSnackBar(
                                       SnackBar(
                                         content: Text(
@@ -515,7 +515,6 @@ class _ProfileViewState extends State<ProfileView> {
 
                                     style: TextStyle(
                                       fontSize: 16,
-                                      color: Colors.black,
                                       fontStyle: FontStyle.italic,
                                     ),
                                   ),
@@ -542,7 +541,6 @@ class _ProfileViewState extends State<ProfileView> {
                                                   context,
                                                 ).showSnackBar(
                                                   SnackBar(
-                                                    backgroundColor: Colors.red,
                                                     content: Text(
                                                       "Error accepting friend request. Please try again or contact support: ${viewmodel.errorMessage}",
                                                     ),
@@ -605,7 +603,6 @@ class _ProfileViewState extends State<ProfileView> {
                                                   context,
                                                 ).showSnackBar(
                                                   SnackBar(
-                                                    backgroundColor: Colors.red,
                                                     content: Text(
                                                       "Error rejecting friend request. Please try again or contact support: ${viewmodel.errorMessage}",
                                                     ),
@@ -656,42 +653,15 @@ class _ProfileViewState extends State<ProfileView> {
                           ),
                         if (!isCurrentUser && isFriend())
                           Padding(
-                            padding: EdgeInsets.only(top: 20),
-                            child: ElevatedButton(
-                              style: ElevatedButton.styleFrom(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 30,
-                                  vertical: 13,
-                                ),
-                                foregroundColor: Colors.white,
-                                backgroundColor: Colors.red,
-                              ),
-                              child:
-                                  viewmodel.isBusy
-                                      ? const CircularProgressIndicator()
-                                      : SizedBox(
-                                        width: 150,
-                                        child: Row(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.center,
-
-                                          children: [
-                                            Icon(
-                                              Icons.delete,
-                                              size: 18,
-                                              color: Colors.white,
-                                            ),
-                                            SizedBox(width: 5.0),
-                                            const Text(
-                                              "Delete friend",
-                                              style: TextStyle(
-                                                fontWeight: FontWeight.bold,
-                                                fontSize: 16.0,
-                                              ),
-                                            ),
-                                          ],
-                                        ),
-                                      ),
+                            padding: EdgeInsets.only(
+                              top: 20,
+                              left: 60,
+                              right: 60,
+                            ),
+                            child: DestructiveButton(
+                              label: 'Delete Friend',
+                              isLoading: viewmodel.isBusy,
+                              icon: Icons.delete,
                               onPressed: () async {
                                 final alert = AlertDialog(
                                   title: Text(
@@ -711,58 +681,42 @@ class _ProfileViewState extends State<ProfileView> {
                                         await viewmodel.deleteFriend(context);
 
                                         if (viewmodel.hasError) {
-                                          if (context.mounted) {
-                                            ScaffoldMessenger.of(
-                                              context,
-                                            ).showSnackBar(
-                                              SnackBar(
-                                                backgroundColor: Colors.red,
-                                                content: Text(
-                                                  "Error deleting friend. Please try again or contact support: ${viewmodel.errorMessage}",
-                                                ),
+                                          ScaffoldMessenger.of(
+                                            context,
+                                          ).showSnackBar(
+                                            SnackBar(
+                                              content: Text(
+                                                "Error deleting friend. Please try again or contact support: ${viewmodel.errorMessage}",
                                               ),
-                                            );
-                                          }
+                                            ),
+                                          );
                                         } else {
-                                          if (context.mounted) {
-                                            if (context.mounted) {
-                                              Navigator.pop(context);
-                                              Navigator.pop(context);
-                                              await Provider.of<
-                                                FriendsViewmodel
-                                              >(
-                                                context,
-                                                listen: false,
-                                              ).fetchFriendsAndRequests(
-                                                viewmodel
-                                                    .userService
-                                                    .currentUser!
-                                                    .id,
-                                                context,
-                                              );
-                                            }
-                                            if (context.mounted) {
-                                              ScaffoldMessenger.of(
-                                                context,
-                                              ).showSnackBar(
-                                                SnackBar(
-                                                  content: Text(
-                                                    "Friend deleted: ${user.firstName} ${user.lastName}",
-                                                  ),
-                                                ),
-                                              );
-                                            }
-                                          }
+                                          Navigator.pop(context);
+                                          Navigator.pop(context);
+                                          await Provider.of<FriendsViewmodel>(
+                                            context,
+                                            listen: false,
+                                          ).fetchFriendsAndRequests(
+                                            viewmodel
+                                                .userService
+                                                .currentUser!
+                                                .id,
+                                            context,
+                                          );
                                         }
+                                        ScaffoldMessenger.of(
+                                          context,
+                                        ).showSnackBar(
+                                          SnackBar(
+                                            content: Text(
+                                              "Friend deleted: ${user.firstName} ${user.lastName}",
+                                            ),
+                                          ),
+                                        );
                                       },
                                     ),
                                     TextButton(
-                                      child: Text(
-                                        "No",
-                                        style: TextStyle(
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                      ),
+                                      child: Text("No"),
                                       onPressed: () {
                                         Navigator.pop(context);
                                       },
@@ -793,27 +747,22 @@ class _ProfileViewState extends State<ProfileView> {
                               onPressed: () async {
                                 await viewmodel.addFriend(context);
                                 if (viewmodel.hasError) {
-                                  if (context.mounted) {
-                                    ScaffoldMessenger.of(context).showSnackBar(
-                                      SnackBar(
-                                        backgroundColor: Colors.red,
-                                        content: Text(
-                                          "Error adding friend: an error occurred or this person is already your friend: ${viewmodel.errorMessage}",
-                                          style: TextStyle(color: Colors.white),
-                                        ),
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text(
+                                        "Error adding friend: an error occurred or this person is already your friend: ${viewmodel.errorMessage}",
+                                        style: TextStyle(color: Colors.white),
                                       ),
-                                    );
-                                  }
+                                    ),
+                                  );
                                 } else {
-                                  if (context.mounted) {
-                                    ScaffoldMessenger.of(context).showSnackBar(
-                                      SnackBar(
-                                        content: Text(
-                                          "Friend request sent successfully!",
-                                        ),
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text(
+                                        "Friend request sent successfully!",
                                       ),
-                                    );
-                                  }
+                                    ),
+                                  );
                                 }
                               },
                               child:
@@ -881,7 +830,6 @@ class _ProfileViewState extends State<ProfileView> {
                                               context,
                                             ).showSnackBar(
                                               SnackBar(
-                                                backgroundColor: Colors.red,
                                                 content: Text(
                                                   "Error canceling friend request. Please try again or contact support: ${viewmodel.errorMessage}",
                                                 ),

--- a/lib/ui/views/profile_view.dart
+++ b/lib/ui/views/profile_view.dart
@@ -376,8 +376,8 @@ class _ProfileViewState extends State<ProfileView> {
                             children: [
                               ElevatedButton(
                                 style: ElevatedButton.styleFrom(
-                                  backgroundColor: Colors.grey,
-                                  foregroundColor: Colors.white,
+                                  // backgroundColor: Colors.grey,
+                                  // foregroundColor: Colors.white,
                                   padding: EdgeInsets.symmetric(
                                     horizontal: 20,
                                     vertical: 13,
@@ -432,8 +432,8 @@ class _ProfileViewState extends State<ProfileView> {
                               SizedBox(height: 16),
                               ElevatedButton(
                                 style: ElevatedButton.styleFrom(
-                                  backgroundColor: Colors.grey,
-                                  foregroundColor: Colors.white,
+                                  // backgroundColor: Colors.grey,
+                                  // foregroundColor: Colors.white,
                                   padding: EdgeInsets.symmetric(
                                     horizontal: 20,
                                     vertical: 13,
@@ -860,7 +860,6 @@ class _ProfileViewState extends State<ProfileView> {
 
                                     style: TextStyle(
                                       fontSize: 16,
-                                      color: Colors.black,
                                       fontStyle: FontStyle.italic,
                                     ),
                                   ),

--- a/lib/ui/views/settings_view.dart
+++ b/lib/ui/views/settings_view.dart
@@ -1,11 +1,35 @@
+import 'package:eventura/core/viewmodels/settings_viewmodel.dart';
 import 'package:flutter/material.dart';
-import 'package:eventura/ui/static/coming_soon.dart';
+import 'package:provider/provider.dart';
 
 class SettingsView extends StatelessWidget {
   const SettingsView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return ComingSoon(title: 'Settings');
+    final viewModel = Provider.of<SettingsViewmodel>(context);
+    viewModel.loadSettings();
+
+    return Consumer<SettingsViewmodel>(
+      builder:
+          (context, viewModel, child) => Scaffold(
+            appBar: AppBar(title: Text('Settings')),
+            body: Padding(
+              padding: const EdgeInsets.all(20.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text("Enable Dark Mode", style: TextStyle(fontSize: 18)),
+                  Switch(
+                    value: !viewModel.settings.lightMode,
+                    onChanged: (_) {
+                      viewModel.toggleDarkMode();
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+    );
   }
 }

--- a/lib/ui/views/settings_view.dart
+++ b/lib/ui/views/settings_view.dart
@@ -2,33 +2,59 @@ import 'package:eventura/core/viewmodels/settings_viewmodel.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-class SettingsView extends StatelessWidget {
+class SettingsView extends StatefulWidget {
   const SettingsView({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final viewModel = Provider.of<SettingsViewmodel>(context);
-    viewModel.loadSettings();
+  State<SettingsView> createState() => _SettingsViewState();
+}
 
+class _SettingsViewState extends State<SettingsView> {
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSettings();
+  }
+
+  Future<void> _loadSettings() async {
+    final viewModel = Provider.of<SettingsViewmodel>(context, listen: false);
+    await viewModel.loadSettings();
+    if (mounted) {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Consumer<SettingsViewmodel>(
       builder:
           (context, viewModel, child) => Scaffold(
             appBar: AppBar(title: Text('Settings')),
-            body: Padding(
-              padding: const EdgeInsets.all(20.0),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text("Enable Dark Mode", style: TextStyle(fontSize: 18)),
-                  Switch(
-                    value: !viewModel.settings.lightMode,
-                    onChanged: (_) {
-                      viewModel.toggleDarkMode();
-                    },
-                  ),
-                ],
-              ),
-            ),
+            body:
+                _isLoading
+                    ? Center(child: CircularProgressIndicator())
+                    : Padding(
+                      padding: const EdgeInsets.all(20.0),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            "Enable Dark Mode",
+                            style: Theme.of(context).textTheme.bodyLarge,
+                          ),
+                          Switch(
+                            value: !viewModel.settings.lightMode,
+                            onChanged: (_) {
+                              viewModel.toggleDarkMode();
+                            },
+                          ),
+                        ],
+                      ),
+                    ),
           ),
     );
   }

--- a/lib/ui/widgets/auth_wrapper.dart
+++ b/lib/ui/widgets/auth_wrapper.dart
@@ -8,7 +8,6 @@ class AuthWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    //Supabase.instance.client.auth.signOut();
     final user = Supabase.instance.client.auth.currentUser;
 
     if (user != null) {

--- a/lib/ui/widgets/custom_button.dart
+++ b/lib/ui/widgets/custom_button.dart
@@ -1,1 +1,0 @@
-class CustomButton {}

--- a/lib/ui/widgets/destructive_button.dart
+++ b/lib/ui/widgets/destructive_button.dart
@@ -1,0 +1,49 @@
+import 'package:eventura/ui/shared/app_colors.dart';
+import 'package:flutter/material.dart';
+
+class DestructiveButton extends StatelessWidget {
+  final VoidCallback onPressed;
+  final bool isLoading;
+  final String label;
+  final IconData icon;
+
+  const DestructiveButton({
+    super.key,
+    required this.onPressed,
+    required this.isLoading,
+    required this.label,
+    required this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicWidth(
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.errorRed,
+          foregroundColor: Colors.white,
+        ),
+
+        onPressed: onPressed,
+        child:
+            isLoading
+                ? const CircularProgressIndicator()
+                : Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(icon, size: 20, color: Colors.white),
+                    const SizedBox(width: 7),
+                    Text(
+                      label,
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/event_card.dart
+++ b/lib/ui/widgets/event_card.dart
@@ -10,11 +10,15 @@ class EventCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       child: ListTile(
-        title: Text(
-          event.title,
-          style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16.0,
+          vertical: 12.0,
         ),
-        subtitle: Text(event.location),
+        title: Text(event.title, style: Theme.of(context).textTheme.titleLarge),
+        subtitle: Padding(
+          padding: const EdgeInsets.only(top: 8.0),
+          child: Text(event.location),
+        ),
         onTap: () {
           Navigator.pushNamed(
             context,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -328,6 +328,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
   gotrue:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -697,13 +697,13 @@ packages:
     source: hosted
     version: "0.28.0"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "846849e3e9b68f3ef4b60c60cf4b3e02e9321bc7f4d8c4692cf87ffa82fc8a3a"
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.2"
+    version: "2.5.3"
   shared_preferences_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
     flutter_launcher_icons: ^0.13.1
     shared_preferences: ^2.5.3
     collection: ^1.19.1
+    google_fonts: ^6.2.1
 
 dev_dependencies:
     flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
     mocktail: ^1.0.4
     http: ^1.3.0
     flutter_launcher_icons: ^0.13.1
+    shared_preferences: ^2.5.3
     collection: ^1.19.1
 
 dev_dependencies:


### PR DESCRIPTION
This pull request derives from #47 by @Narodk1 which had too much messy platform-related, device-specific and auto-generated files changed and was closed.
Settings feature implementation: only light mode preference for the moment.
The MaterialApp widget was wrapped with a `Consumer` for the settings view model.
Settings viewmodel calls the settings service to load the data from the local shared preferences and to set the boolean light mode property to true or false to toggle between light and dark mode, the information is stored locally using a settings model which holds the boolean property.
Settings view is a simple scaffold with a switch to turn on/off light mode.
App colors and app theme were naturally added with a good amount of properties, though a lot are lacking and the project files were not changed to integrate the new features.
A few of the bugs and issues that were spotted during testing run:

- a lot of the colors in all code files are hardcoded and need to call `Theme.of(context)` and fetch standardized properties for the whole project
- Search bar in dark mode has black title even in dark mode
- Relationship-specific messages's color before relationship-specific buttons when the user looks at another user's profile doesn't adapt to dark mode and are thus invisible.
- Non UI-related: when the user taps "Save changes" without having made any change, a "Profile updated" snack bar still appears to the screen after the one signaling no change was made.
- create event form is too tight, some `SizedBox` widgets with height could be added
- The switch color when enabled isn't really good in dark mode
- the icons color isn't good in dark mode for reset password and sign out in profile view
- suggestion: in dialog boxes, elevated choice buttons could have a background color to make the dialog box more appealing
- in light mode, Location and Description texts are white in event detail view, making them barely visible
- in dark mode the event cards' background color when displayed in favorites or in events list in the homepage, or even dialog boxes background color, are too dark (bad contrast with the dark default background)
- suggestion: the logo of the app could be added in the center of the screen in the top (first column element) in both signup and login views
- a 'null check on null value' error happens between tapping sign out (profile page) and the redirection to the 'sign in' page